### PR TITLE
[Fix] Check push tags versions aligned with code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,44 @@ jobs:
       - name: Install pnpm
         run: npm install -g pnpm
 
+      - name: Get latest tag
+        id: latest_tag
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_ENV
+
+      - name: Extract Cargo version
+        id: cargo_version
+        run: |
+          CARGO_VERSION=$(grep -E "^version\s*=" Cargo.toml | cut -d'"' -f2)
+          echo "cargo_version=$CARGO_VERSION" >> $GITHUB_ENV
+
+      - name: Extract package.json version
+        id: package_version
+        run: |
+          PACKAGE_VERSION=$(node -e "console.log(require('./web/package.json').version)")
+          echo "package_version=$PACKAGE_VERSION" >> $GITHUB_ENV
+
+      - name: Validate versions match
+        if: env.latest_tag != ''
+        run: |
+          echo "Latest tag: ${{ env.latest_tag }}"
+          echo "Cargo version: ${{ env.cargo_version }}"
+          echo "Package version: ${{ env.package_version }}"
+
+          TAG_CLEAN="${{ env.latest_tag }}"
+          TAG_CLEAN="${TAG_CLEAN#v}"
+
+          if [ "$TAG_CLEAN" = "${{ env.cargo_version }}" ] && [ "$TAG_CLEAN" = "${{ env.package_version }}" ]; then
+            echo "✓ All versions match"
+          else
+            echo "✗ Version mismatch detected"
+            echo "  Tag: ${{ env.latest_tag }}"
+            echo "  Cargo version: ${{ env.cargo_version }}"
+            echo "  Package version: ${{ env.package_version }}"
+            exit 1
+          fi
+
       - name: Build frontend (web)
         working-directory: ./web
         run: |


### PR DESCRIPTION
I didn't know why I thought I updated but I didn't until I realised Cargo.toml version wasn't aligned with the tag. So I added a step to ensure it does work. I tested locally with nektos/act and it works well.

I also made this pre-push hook but can't seem able to push it:
```bash
#!/bin/bash

# Get the latest tag
latest_tag=$(git describe --tags --abbrev=0 2>/dev/null)

# If no tags exist, exit gracefully
if [ -z "$latest_tag" ]; then
    echo "No tags found in repository"
    exit 0
fi

echo "Latest tag: $latest_tag"

# Extract version from Cargo.toml
cargo_version=$(grep -E "^version\s*=" Cargo.toml | cut -d'"' -f2)

# Extract version from package.json
package_version=$(node -e "console.log(require('./web/package.json').version)" 2>/dev/null)

# Check if versions exist
if [ -z "$cargo_version" ]; then
    echo "Error: Could not extract version from Cargo.toml"
    exit 1
fi

if [ -z "$package_version" ]; then
    echo "Error: Could not extract version from package.json"
    exit 1
fi

echo "Cargo version: $cargo_version"
echo "Package version: $package_version"

# Check if tag matches versions
tag_without_v=${latest_tag#v}
if [ "$tag_without_v" = "$cargo_version" ] && [ "$tag_without_v" = "$package_version" ]; then
    echo "✓ Tag matches both Cargo and package versions"
    exit 0
else
    echo "✗ Tag does not match versions"
    echo "  Tag: $latest_tag"
    echo "  Cargo version: $cargo_version"
    echo "  Package version: $package_version"
    exit 1
fi
```