### PR TITLE
feat(api): Add thread_id to SearchFilter

### DIFF
--- a/src/modules/indexer/manager.rs
+++ b/src/modules/indexer/manager.rs
@@ -324,6 +324,14 @@ impl EnvelopeIndexManager {
             ));
         }
 
+        if let Some(thread_id) = filter.thread_id {
+            let term = Term::from_field_u64(f.f_thread_id, thread_id);
+            subqueries.push((
+                Occur::Must,
+                Box::new(TermQuery::new(term, IndexRecordOption::Basic)),
+            ));
+        }
+
         let start_bound = if let Some(from) = filter.min_size {
             Bound::Included(Term::from_field_u64(f.f_size, from))
         } else {

--- a/src/modules/message/search.rs
+++ b/src/modules/message/search.rs
@@ -40,6 +40,7 @@ pub struct SearchFilter {
     pub before: Option<i64>,
     pub account_id: Option<u64>,
     pub mailbox_id: Option<u64>,
+    pub thread_id: Option<u64>,
     pub min_size: Option<u64>,
     pub max_size: Option<u64>,
     pub message_id: Option<String>,


### PR DESCRIPTION
## Summary
Add `thread_id` field to `SearchFilter` to allow searching messages by thread ID via the search API.

This enables users to find all messages belonging to a specific conversation thread, complementing the existing `get-thread-messages` endpoint.

## Changes
- Add `thread_id: Option<u64>` to `SearchFilter` struct in `src/modules/message/search.rs`
- Add thread_id query handling in `filter_query` function in `src/modules/indexer/manager.rs`

## Example Usage
```json
POST /api/v1/search-messages
{
  "filter": {
    "account_id": 5226761534500230,
    "thread_id": 8416787662419872
  },
  "page": 1,
  "page_size": 10
}
```

## Test plan
- [x] Verify SearchFilter schema includes thread_id in OpenAPI spec
- [x] Test search by thread_id returns all messages in the thread
- [x] Verify existing search functionality still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)