### PR TITLE
feat(cli): add an option to specify the encrypt password in a file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "bichon"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "ahash",
  "async-imap",

--- a/README.md
+++ b/README.md
@@ -449,9 +449,12 @@ cargo build
 Or run directly:
 
 ```bash
+export BICHON_ENCRYPT_PASSWORD=dummy-password-for-testing
 cargo run -- --bichon-root-dir e:\bichon-data
 ```
+
 `--bichon-root-dir` specifies the directory where **all Bichon data** will be stored.
+`BICHON_ENCRYPT_PASSWORD` is the password used to encrypt the sensitive data (see `cargo run -- --help` for alternative ways to specify this).
 
 ### WebUI Access
 


### PR DESCRIPTION
From the security point of view it is better to read the secret values from files rather than passing their values directly.

This way, one can put proper permissions on the file, the secret value cannot end up in the shell history, etc.

And thanks for an awesome project!