### PR TITLE
Remove the maximum from the sync_interval_min.

### DIFF
--- a/src/modules/account/payload.rs
+++ b/src/modules/account/payload.rs
@@ -37,7 +37,7 @@ pub struct AccountCreateRequest {
     pub account_type: AccountType,
     #[oai(validator(minimum(value = "100")))]
     pub folder_limit: Option<u32>,
-    #[oai(validator(minimum(value = "10"), maximum(value = "480")))]
+    #[oai(validator(minimum(value = "10")))]
     pub sync_interval_min: Option<i64>,
     #[oai(validator(minimum(value = "30"), maximum(value = "200")))]
     pub sync_batch_size: Option<u32>,
@@ -143,7 +143,7 @@ pub struct AccountUpdateRequest {
     /// Modified folders will be automatically synced on the next update.
     pub sync_folders: Option<Vec<String>>,
     /// Incremental sync interval (seconds)
-    #[oai(validator(minimum(value = "10"), maximum(value = "480")))]
+    #[oai(validator(minimum(value = "10")))]
     pub sync_interval_min: Option<i64>,
     #[oai(validator(minimum(value = "30"), maximum(value = "200")))]
     pub sync_batch_size: Option<u32>,


### PR DESCRIPTION
I'm not sure why the maximum incremental sync interval is set to just 8 hours, but for my usecase, I'd like to set it to at least a couple of days.

E.g. I receive my emails to my regular inbox and many are not worth archiving. I want to give myself some time to process them and delete the "unworthy" ones before bichon copies them over.

Is that thinking ok or would you suggest another approach? 

Note that the "I", "my" and "myself" above mostly refer to my wife that would refuse to remember to copy the "worthy" emails to a dedicated folder for example :)
