### PR TITLE
Support listening on IPv6 addresses

### DIFF
--- a/env/rustmailer.env
+++ b/env/rustmailer.env
@@ -28,7 +28,7 @@ BICHON_ROOT_DIR=/data/bichon-data
 # Enable API access token validation
 BICHON_ENABLE_ACCESS_TOKEN=false
 
-# IP address to bind the HTTP and gRPC servers to (default: 0.0.0.0)
+# IP address to bind the HTTP and gRPC servers to (default: ::)
 BICHON_BIND_IP=
 
 # Comma-separated list of allowed CORS origins (e.g. https://app.example.com)

--- a/src/modules/rest/mod.rs
+++ b/src/modules/rest/mod.rs
@@ -51,7 +51,7 @@ pub type ApiResult<T, E = ApiErrorResponse> = std::result::Result<T, E>;
 
 pub async fn start_http_server() -> BichonResult<()> {
     let listener = TcpListener::bind((
-        SETTINGS.bichon_bind_ip.clone().unwrap_or("0.0.0.0".into()),
+        SETTINGS.bichon_bind_ip.clone().unwrap_or("::".into()),
         SETTINGS.bichon_http_port as u16,
     ));
 

--- a/src/modules/settings/cli.rs
+++ b/src/modules/settings/cli.rs
@@ -50,7 +50,7 @@ pub struct Settings {
     #[clap(
         long,
         env,
-        default_value = "0.0.0.0",
+        default_value = "::",
         help = "The IP address that the node binds to, in IPv4 or IPv6 format (e.g., 192.168.1.1 or ::1). Required in cluster mode.",
         value_parser = ValueParser::new(|s: &str| {
             // Ensure the input is a valid IPv4 or IPv6 address


### PR DESCRIPTION
This PR adds IPv6 support to the bichon_bind_ip configuration and enables dual-stack binding by changing the default bind address to `::`. This change is backwards compatible, the socket will listen on both IPv4 and IPv6, but allows for easier deployment in IPv6-only environments.