### PR TITLE
fix: fallback to internal_date when email date is zero

### DIFF
--- a/src/modules/indexer/envelope.rs
+++ b/src/modules/indexer/envelope.rs
@@ -196,7 +196,14 @@ impl Envelope {
             to: extract_vec_string_field(doc, fields.f_to)?,
             cc: extract_vec_string_field(doc, fields.f_cc)?,
             bcc: extract_vec_string_field(doc, fields.f_bcc)?,
-            date: extract_i64_field(doc, fields.f_date)?,
+            date: {
+                let d = extract_i64_field(doc, fields.f_date)?;
+                if d == 0 {
+                    extract_i64_field(doc, fields.f_internal_date)?
+                } else {
+                    d
+                }
+            },
             internal_date: extract_i64_field(doc, fields.f_internal_date)?,
             size: extract_u64_field(doc, fields.f_size)? as u32,
             thread_id: extract_u64_field(doc, fields.f_thread_id)?,

--- a/src/modules/indexer/manager.rs
+++ b/src/modules/indexer/manager.rs
@@ -37,8 +37,8 @@ use crate::{
         indexer::{
             envelope::Envelope,
             fields::{
-                F_ACCOUNT_ID, F_DATE, F_FROM, F_HAS_ATTACHMENT, F_MAILBOX_ID, F_SIZE, F_TAGS,
-                F_THREAD_ID, F_UID,
+                F_ACCOUNT_ID, F_DATE, F_FROM, F_HAS_ATTACHMENT, F_INTERNAL_DATE, F_MAILBOX_ID,
+                F_SIZE, F_TAGS, F_THREAD_ID, F_UID,
             },
             schema::SchemaTools,
         },
@@ -726,7 +726,7 @@ impl EnvelopeIndexManager {
                         &query,
                         &TopDocs::with_limit(page_size as usize)
                             .and_offset(offset as usize)
-                            .order_by_fast_field(F_DATE, order),
+                            .order_by_fast_field(F_INTERNAL_DATE, order),
                     )
                     .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InternalError))?;
                 mailbox_docs = date_docs.into_iter().map(|(_, addr)| addr).collect();
@@ -804,7 +804,7 @@ impl EnvelopeIndexManager {
                 query.as_ref(),
                 &TopDocs::with_limit(page_size as usize)
                     .and_offset(offset as usize)
-                    .order_by_fast_field(F_DATE, order),
+                    .order_by_fast_field(F_INTERNAL_DATE, order),
             )
             .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InternalError))?;
         let mut result = Vec::new();
@@ -869,7 +869,7 @@ impl EnvelopeIndexManager {
                 query.as_ref(),
                 &TopDocs::with_limit(page_size as usize)
                     .and_offset(offset as usize)
-                    .order_by_fast_field(F_DATE, order),
+                    .order_by_fast_field(F_INTERNAL_DATE, order),
             )
             .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InternalError))?;
         let mut result = Vec::new();


### PR DESCRIPTION
 - Some emails have a date field of 0 (epoch) because they lack a valid Date header. However, IMAP always provides a reliable internal_date value (the server-received timestamp). This PR uses internal_date as a fallback when date is zero, and switches sort ordering to use internal_date for consistent results.

# Why
Emails without a Date header (or with an unparseable one) get stored with date = 0. This caused:

1. The API returning `1970-01-01` as the date for those emails
2. Sort-by-date placing these emails at the very beginning or end regardless of when they were actually received

`internal_date` is the IMAP INTERNALDATE — the timestamp the server recorded when the message was received — and is always present.