### PR TITLE
Security: Sensitive password field included in API-facing user model

### DIFF
--- a/crates/core/src/users/view.rs
+++ b/crates/core/src/users/view.rs
@@ -30,6 +30,7 @@ pub struct UserView {
     pub username: String,
     pub email: String,
 
+    #[serde(skip_serializing)]
     pub password: Option<String>,
 
     /// Scoped Access: Defines per-account permissions.


### PR DESCRIPTION
## Summary

Security: Sensitive password field included in API-facing user model

## Problem

**Severity**: `High` | **File**: `crates/core/src/users/view.rs:L27`

The `UserView` struct includes `pub password: Option<String>` and is marked as an OpenAPI object. If this struct is serialized in API responses, password material (even hashes) can be exposed to clients, logs, or browser storage.

## Solution

Remove the `password` field from `UserView` entirely, or enforce `#[serde(skip_serializing)]` on it and use a dedicated request DTO for password updates.

## Changes

- `crates/core/src/users/view.rs` (modified)