### PR TITLE
fix: prevent the dedup GC from deleting a still-referenced content blob

### DIFF
--- a/crates/core/src/store/tantivy/envelope.rs
+++ b/crates/core/src/store/tantivy/envelope.rs
@@ -733,7 +733,11 @@ impl IndexManager {
             .await?;
 
         if !eml_content_hashes.is_empty() || !attachments_content_hashes.is_empty() {
-            self.cleanup_unused_content(eml_content_hashes, attachments_content_hashes)?;
+            self.cleanup_unused_content(
+                &mut writer,
+                eml_content_hashes,
+                attachments_content_hashes,
+            )?;
         }
         Ok(())
     }
@@ -772,7 +776,11 @@ impl IndexManager {
             .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InternalError))?;
 
         if !eml_content_hashes.is_empty() || !attachments_content_hashes.is_empty() {
-            self.cleanup_unused_content(eml_content_hashes, attachments_content_hashes)?;
+            self.cleanup_unused_content(
+                &mut writer,
+                eml_content_hashes,
+                attachments_content_hashes,
+            )?;
         }
         Ok(())
     }
@@ -817,9 +825,18 @@ impl IndexManager {
 
     fn cleanup_unused_content(
         &self,
+        writer: &mut IndexWriter,
         eml_content_hashes: HashSet<String>,
         attachments_content_hashes: HashSet<String>,
     ) -> BichonResult<()> {
+        // Reference-count barrier: commit the writer and reload the reader so the
+        // `Count` below is evaluated against a fully committed, freshly-reloaded
+        // index state. Without this, an envelope that shares a content hash but
+        // is still sitting uncommitted in the writer buffer (e.g. added by the
+        // background ingest task before this delete acquired the writer lock)
+        // would be invisible to the searcher, the count would read 0, and a
+        // still-referenced blob would be deleted.
+        fatal_commit(writer);
         let searcher = self.create_searcher()?;
         let fields = SchemaTools::email_fields();
         let mut eml: HashSet<String> = HashSet::new();
@@ -900,7 +917,11 @@ impl IndexManager {
             .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InternalError))?;
 
         if !eml_content_hashes.is_empty() || !attachments_content_hashes.is_empty() {
-            self.cleanup_unused_content(eml_content_hashes, attachments_content_hashes)?;
+            self.cleanup_unused_content(
+                &mut writer,
+                eml_content_hashes,
+                attachments_content_hashes,
+            )?;
         }
 
         Ok(())


### PR DESCRIPTION
## Problem

`cleanup_unused_content` (`crates/core/src/store/tantivy/envelope.rs`) is the reference-counted GC for the deduplicated blob store. It decides whether to delete a blob by running a Tantivy `Count` of envelopes still referencing each `content_hash` — using a searcher that reflects only the **committed** index state.

An envelope that shares a `content_hash` but is still buffered, uncommitted, in the `IndexWriter` — e.g. just added by the background ingest task, which commits only on a 1000-doc threshold or a 60s interval — is invisible to that `Count`. The count reads 0, the still-referenced blob is deleted, and that envelope's `download-message` then returns `404 [30000] Original email content not found` permanently.

A plausible cause of sporadic, hard-to-reproduce content loss — see #256.

## Fix

`cleanup_unused_content` now takes the locked `&mut IndexWriter` and calls `fatal_commit(writer)` immediately before building the searcher, flushing any pending docs. `create_searcher()` already reloads the reader, so the reference `Count` is now evaluated against a fully committed, freshly-reloaded index.

The three callers (`delete_account_envelopes`, `delete_mailbox_envelopes`, `delete_envelopes_multi_account`) already hold the `index_writer` mutex at the call site — they pass `&mut writer`, so the barrier reuses that lock (no extra acquisition, no deadlock). `fatal_commit` is the file's existing commit primitive. The barrier is self-contained inside the GC function, correct regardless of what the caller committed.

## Testing

Built and tested with a nightly toolchain (`rustc 1.95.0-nightly`): the committed `Cargo.lock` pins `sysinfo 0.39.2`, which requires `rustc >= 1.95`, so the workspace does not build with a stable `1.92` — a pre-existing toolchain matter unrelated to this change.

- `bichon-core` compiles cleanly with the change.
- `cargo test -p bichon-core`: 111 passed, 5 failed — the 5 failures need external infrastructure (EML fixtures, a live IMAP server, an on-disk Tantivy dir) and are **identical on unmodified HEAD** (verified via `git stash`). No new failures; the dedup tests pass.

Fixes #256.
