### PR TITLE
feat: filter and sort search-messages by a server-side timestamp

### DIFF
--- a/crates/core/src/message/search.rs
+++ b/crates/core/src/message/search.rs
@@ -74,9 +74,11 @@ pub enum SortBy {
     SIZE,
     /// Sort by the IMAP server INTERNALDATE timestamp.
     #[serde(rename = "INTERNAL_DATE")]
+    #[cfg_attr(feature = "web-api", oai(rename = "INTERNAL_DATE"))]
     InternalDate,
     /// Sort by Bichon's archival (ingest) timestamp.
     #[serde(rename = "INGEST_AT")]
+    #[cfg_attr(feature = "web-api", oai(rename = "INGEST_AT"))]
     IngestAt,
 }
 

--- a/crates/core/src/message/search.rs
+++ b/crates/core/src/message/search.rs
@@ -45,6 +45,14 @@ pub struct EmailSearchFilter {
     pub bcc: Option<String>,
     pub since: Option<i64>,
     pub before: Option<i64>,
+    /// Lower bound (inclusive) on the IMAP server INTERNALDATE timestamp.
+    pub internal_date_since: Option<i64>,
+    /// Upper bound (inclusive) on the IMAP server INTERNALDATE timestamp.
+    pub internal_date_before: Option<i64>,
+    /// Lower bound (inclusive) on Bichon's archival (ingest) timestamp.
+    pub ingest_since: Option<i64>,
+    /// Upper bound (inclusive) on Bichon's archival (ingest) timestamp.
+    pub ingest_before: Option<i64>,
     pub account_ids: Option<HashSet<u64>>,
     pub mailbox_ids: Option<HashSet<u64>>,
     pub min_size: Option<u64>,
@@ -64,6 +72,12 @@ pub enum SortBy {
     #[default]
     DATE,
     SIZE,
+    /// Sort by the IMAP server INTERNALDATE timestamp.
+    #[serde(rename = "INTERNAL_DATE")]
+    InternalDate,
+    /// Sort by Bichon's archival (ingest) timestamp.
+    #[serde(rename = "INGEST_AT")]
+    IngestAt,
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/core/src/store/tantivy/attachment.rs
+++ b/crates/core/src/store/tantivy/attachment.rs
@@ -38,8 +38,8 @@ use crate::{
     store::tantivy::{
         fatal_commit,
         fields::{
-            F_ATTACHMENT_CATEGORY, F_ATTACHMENT_CONTENT_TYPE, F_ATTACHMENT_EXT, F_DATE, F_SIZE,
-            F_TAGS,
+            F_ATTACHMENT_CATEGORY, F_ATTACHMENT_CONTENT_TYPE, F_ATTACHMENT_EXT, F_DATE,
+            F_INGEST_AT, F_SIZE, F_TAGS,
         },
         model::{extract_senders, AttachmentModel},
         schema::SchemaTools,
@@ -863,6 +863,30 @@ impl IndexManager {
                     )
                     .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InternalError))?;
                 attachment_docs = size_docs.into_iter().map(|(_, addr)| addr).collect();
+            }
+            // Attachments carry no IMAP INTERNALDATE; fall back to the
+            // attachment's own date field so the sort remains well defined.
+            SortBy::InternalDate => {
+                let date_docs: Vec<(Option<i64>, DocAddress)> = searcher
+                    .search(
+                        &query,
+                        &TopDocs::with_limit(page_size as usize)
+                            .and_offset(offset as usize)
+                            .order_by_fast_field(F_DATE, order),
+                    )
+                    .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InternalError))?;
+                attachment_docs = date_docs.into_iter().map(|(_, addr)| addr).collect();
+            }
+            SortBy::IngestAt => {
+                let ingest_at_docs: Vec<(Option<i64>, DocAddress)> = searcher
+                    .search(
+                        &query,
+                        &TopDocs::with_limit(page_size as usize)
+                            .and_offset(offset as usize)
+                            .order_by_fast_field(F_INGEST_AT, order),
+                    )
+                    .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InternalError))?;
+                attachment_docs = ingest_at_docs.into_iter().map(|(_, addr)| addr).collect();
             }
         }
 

--- a/crates/core/src/store/tantivy/envelope.rs
+++ b/crates/core/src/store/tantivy/envelope.rs
@@ -42,8 +42,8 @@ use crate::{
             attachment::ATTACHMENT_MANAGER,
             fatal_commit,
             fields::{
-                F_ACCOUNT_ID, F_DATE, F_FROM, F_ID, F_REGULAR_ATTACHMENT_COUNT, F_SIZE, F_TAGS,
-                F_THREAD_ID, F_UID,
+                F_ACCOUNT_ID, F_DATE, F_FROM, F_ID, F_INGEST_AT, F_INTERNAL_DATE,
+                F_REGULAR_ATTACHMENT_COUNT, F_SIZE, F_TAGS, F_THREAD_ID, F_UID,
             },
             model::{extract_contacts, EnvelopeWithAttachments},
             schema::SchemaTools,
@@ -448,6 +448,40 @@ impl IndexManager {
 
         let end_bound = if let Some(to) = filter.before {
             Bound::Included(Term::from_field_i64(f.f_date, to))
+        } else {
+            Bound::Unbounded
+        };
+
+        if start_bound != Bound::Unbounded || end_bound != Bound::Unbounded {
+            let q = RangeQuery::new(start_bound, end_bound);
+            subqueries.push((Occur::Must, Box::new(q)));
+        }
+
+        let start_bound = if let Some(from) = filter.internal_date_since {
+            Bound::Included(Term::from_field_i64(f.f_internal_date, from))
+        } else {
+            Bound::Unbounded
+        };
+
+        let end_bound = if let Some(to) = filter.internal_date_before {
+            Bound::Included(Term::from_field_i64(f.f_internal_date, to))
+        } else {
+            Bound::Unbounded
+        };
+
+        if start_bound != Bound::Unbounded || end_bound != Bound::Unbounded {
+            let q = RangeQuery::new(start_bound, end_bound);
+            subqueries.push((Occur::Must, Box::new(q)));
+        }
+
+        let start_bound = if let Some(from) = filter.ingest_since {
+            Bound::Included(Term::from_field_i64(f.f_ingest_at, from))
+        } else {
+            Bound::Unbounded
+        };
+
+        let end_bound = if let Some(to) = filter.ingest_before {
+            Bound::Included(Term::from_field_i64(f.f_ingest_at, to))
         } else {
             Bound::Unbounded
         };
@@ -1140,6 +1174,31 @@ impl IndexManager {
                     )
                     .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InternalError))?;
                 mailbox_docs = size_docs.into_iter().map(|(_, addr)| addr).collect();
+            }
+            SortBy::InternalDate => {
+                let internal_date_docs: Vec<(Option<i64>, DocAddress)> = searcher
+                    .search(
+                        &query,
+                        &TopDocs::with_limit(page_size as usize)
+                            .and_offset(offset as usize)
+                            .order_by_fast_field(F_INTERNAL_DATE, order),
+                    )
+                    .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InternalError))?;
+                mailbox_docs = internal_date_docs
+                    .into_iter()
+                    .map(|(_, addr)| addr)
+                    .collect();
+            }
+            SortBy::IngestAt => {
+                let ingest_at_docs: Vec<(Option<i64>, DocAddress)> = searcher
+                    .search(
+                        &query,
+                        &TopDocs::with_limit(page_size as usize)
+                            .and_offset(offset as usize)
+                            .order_by_fast_field(F_INGEST_AT, order),
+                    )
+                    .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InternalError))?;
+                mailbox_docs = ingest_at_docs.into_iter().map(|(_, addr)| addr).collect();
             }
         }
 


### PR DESCRIPTION
## Problem

`POST /api/v1/search-messages` filters and sorts only on the sender-controlled `Date:` header — which can be missing, malformed, or wrong; archived messages have been observed with a null `Date:`. There is no reliable cursor for incremental synchronisation. See #254.

## Fix

Add `internal_date` (the IMAP INTERNALDATE) and `ingest_at` (Bichon's archival time) as filter and sort options. Both are **already** declared in the Tantivy email schema as `INDEXED | STORED | FAST` and populated on every document — so no re-index or migration is required.

- `EmailSearchFilter` gains `internal_date_since` / `internal_date_before` and `ingest_since` / `ingest_before` range bounds, mirroring the existing `since` / `before` `Date:` handling.
- `SortBy` gains `InternalDate` and `IngestAt` (wire values `INTERNAL_DATE` / `INGEST_AT`, matching the existing `DATE` / `SIZE`).
- `filter_query` gets two `RangeQuery` blocks and the message `search` sort gets two `order_by_fast_field` arms, mirroring the `Date:` ones.
- `ATTACHMENT_MANAGER.search` shares the `SortBy` enum; its match is extended to stay exhaustive — `IngestAt` maps to the attachment's `ingest_at`, `InternalDate` falls back to the attachment date field (attachments carry no IMAP INTERNALDATE; documented in a comment).

## Testing

Built and tested with a nightly toolchain (`rustc 1.95.0-nightly`): the committed `Cargo.lock` pins `sysinfo 0.39.2`, which requires `rustc >= 1.95`, so the workspace does not build with a stable `1.92` — a pre-existing toolchain matter unrelated to this change.

- `cargo build` (full workspace): passes.
- `cargo test -p bichon-core`: 111 passed, 5 failed — the 5 failures need external infrastructure and are identical on unmodified HEAD. `cargo test -p bichon-server`: 38 passed, 0 failed.
- `clippy` and `fmt`: identical to baseline — zero new warnings or formatting changes.

Closes #254.
