### PR TITLE
Feat: yahoo export imap server

### DIFF
--- a/crates/core/src/autoconfig/load.rs
+++ b/crates/core/src/autoconfig/load.rs
@@ -36,13 +36,40 @@ pub(crate) fn socket_type_to_encryption(raw: &str) -> Encryption {
     }
 }
 
+/// Check if the configuration is for a Yahoo Mail account
+fn is_yahoo_config(config: &MailConfig) -> bool {
+    config.incoming.iter().any(|s| {
+        s.hostname.contains("yahoo") 
+            || s.hostname.contains("ymail") 
+            || s.hostname.contains("rocketmail")
+    })
+}
+
 /// Convert the raw `MailConfig` discovered by `client::fetch` into a
 /// `MailServerConfig` suitable for account provisioning.
+/// 
+/// For Yahoo Mail accounts, prioritizes the export IMAP server (export.imap.mail.yahoo.com)
+/// for better archive retrieval. Falls back to the standard IMAP server if the export
+/// server is not available.
 pub(crate) fn mail_config_to_server_config(config: &MailConfig) -> Option<MailServerConfig> {
-    let imap = config.incoming.iter().find(|s| {
-        let p = s.protocol.to_ascii_lowercase();
-        p == "imap" || p == "imaps"
-    })?;
+    // For Yahoo Mail, try to prioritize the export server
+    let imap = if is_yahoo_config(config) {
+        // Try export server first, then fall back to standard IMAP server
+        config.incoming.iter().find(|s| {
+            let p = s.protocol.to_ascii_lowercase();
+            (p == "imap" || p == "imaps") && s.hostname.contains("export.imap")
+        }).or_else(|| {
+            config.incoming.iter().find(|s| {
+                let p = s.protocol.to_ascii_lowercase();
+                p == "imap" || p == "imaps"
+            })
+        })
+    } else {
+        config.incoming.iter().find(|s| {
+            let p = s.protocol.to_ascii_lowercase();
+            p == "imap" || p == "imaps"
+        })
+    }?;
 
     let encryption = socket_type_to_encryption(&imap.socket_type);
     let port = if imap.port != 0 {

--- a/crates/core/src/autoconfig/tests.rs
+++ b/crates/core/src/autoconfig/tests.rs
@@ -306,3 +306,51 @@ fn convert_case_insensitive_protocol() {
     let result = mail_config_to_server_config(&config).expect("should recognize 'IMAP'");
     assert_eq!(result.imap.host, "imap.example.com");
 }
+
+// ---------------------------------------------------------------------------
+// Yahoo Mail export server prioritization tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn yahoo_prioritizes_export_imap_server() {
+    let config = MailConfig {
+        incoming: vec![
+            make_imap_server("imap.mail.yahoo.com", 993, "SSL"),
+            IncomingServer {
+                protocol: "imap".to_string(),
+                hostname: "export.imap.mail.yahoo.com".to_string(),
+                port: 993,
+                socket_type: "SSL".to_string(),
+                username: "%EMAILADDRESS%".to_string(),
+            },
+        ],
+        outgoing: vec![],
+    };
+    let result = mail_config_to_server_config(&config).expect("should find IMAP");
+    assert_eq!(result.imap.host, "export.imap.mail.yahoo.com");
+}
+
+#[test]
+fn yahoo_falls_back_to_standard_imap() {
+    let config = MailConfig {
+        incoming: vec![
+            make_imap_server("imap.mail.yahoo.com", 993, "SSL"),
+        ],
+        outgoing: vec![],
+    };
+    let result = mail_config_to_server_config(&config).expect("should find IMAP");
+    assert_eq!(result.imap.host, "imap.mail.yahoo.com");
+}
+
+#[test]
+fn non_yahoo_uses_first_imap_server() {
+    let config = MailConfig {
+        incoming: vec![
+            make_imap_server("imap.example.com", 993, "SSL"),
+            make_imap_server("imap2.example.com", 993, "SSL"),
+        ],
+        outgoing: vec![],
+    };
+    let result = mail_config_to_server_config(&config).expect("should find IMAP");
+    assert_eq!(result.imap.host, "imap.example.com");
+}


### PR DESCRIPTION
## Motivation
Fixes #271 - incomplete archive via IMAP for Yahoo Mail accounts

## Changes
- Prioritizes `export.imap.mail.yahoo.com` for Yahoo Mail account auto-configuration
- Falls back to `imap.mail.yahoo.com` if the export server is unavailable
- Helps resolve issues with folder listing showing fewer emails than actually present
- Includes comprehensive test coverage for Yahoo account detection and server selection

## References
- Related issue: #271
- Yahoo Mail autoconfig: https://github.com/thunderbird/autoconfig/blob/master/ispdb/yahoo.com.xml#L39-L46