### PR TITLE
docker changed to two stage build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,41 +1,55 @@
-# Use Debian bullseye-slim as the base image for newer OpenSSL
-FROM ubuntu:24.04
-ARG CRATE_VERSION
-ARG TARGETARCH
+# ── Stage 1: builder ─────────────────────────────────────────────────────────
+FROM rust:slim-bookworm AS builder
 
-# Set maintainer metadata
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    pkg-config \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g pnpm@9.14 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Cache frontend dependencies separately from source
+COPY web/package.json web/pnpm-lock.yaml web/
+RUN cd web && pnpm install --frozen-lockfile
+
+# Build frontend first (embedded into Rust binary via rust-embed)
+COPY web/ web/
+RUN cd web && pnpm run build
+
+# Build Rust
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
+COPY about.hbs about.toml ./
+COPY .git .git
+
+RUN git config --global --add safe.directory /build && cargo build --release
+
+# ── Stage 2: runtime ─────────────────────────────────────────────────────────
+FROM debian:bookworm-slim
+
+ARG CRATE_VERSION
 LABEL maintainer="rustmailer <rustmailer.git@gmail.com>"
 LABEL version="${CRATE_VERSION}"
 LABEL description="Dockerized Bichon service"
 
-# Set working directory
-WORKDIR /opt/bichon
+RUN apt-get update && apt-get install -y ca-certificates curl && rm -rf /var/lib/apt/lists/*
 
-# Copy compiled binary (ensure it's statically linked or compatible with bullseye)
-COPY ${TARGETARCH}/bichon-server /opt/bichon/bichon-server
-COPY ${TARGETARCH}/LICENSE /opt/bichon/
+COPY --from=builder /build/target/release/bichon-server  /opt/bichon/bichon-server
+COPY --from=builder /build/target/release/bichon-cli     /usr/local/bin/bichon-cli
+COPY --from=builder /build/target/release/bichon-admin   /usr/local/bin/bichon-admin
+COPY LICENSE /opt/bichon/LICENSE
 
+RUN chmod +x /opt/bichon/bichon-server \
+    && chmod +x /usr/local/bin/bichon-cli \
+    && chmod +x /usr/local/bin/bichon-admin \
+    && mkdir -p /data
 
-# cli tools
-COPY ${TARGETARCH}/bichon-cli /usr/local/bin/bichon-cli
-COPY ${TARGETARCH}/bichon-admin /usr/local/bin/bichon-admin
-
-# Set permissions
-RUN chmod +x /opt/bichon/bichon-server
-RUN chmod +x /usr/local/bin/bichon-cli
-RUN chmod +x /usr/local/bin/bichon-admin
-
-
-# Install ca-certificates to ensure HTTPS certificate verification works correctly
-RUN apt update && apt install -y ca-certificates curl && rm -rf /var/lib/apt/lists/*
-# Create data directory
-RUN mkdir -p /data
-
-# Expose default ports
-EXPOSE 15630
-
-# Set volume and working directory
 WORKDIR /data
+EXPOSE 15630
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
   CMD curl -fs http://localhost:15630/api/status || exit 1

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,31 +1,14 @@
 #!/bin/bash
+set -e
 
-# Step 0: Build frontend with pnpm in ../web
-echo "Step 0: Building frontend in ../web using pnpm..."
-cd ../web || { echo "Failed to enter ../web directory"; exit 1; }
-pnpm run build || { echo "Frontend build failed"; exit 1; }
+VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' ../Cargo.toml | head -1)
+echo "Building bichon $VERSION"
 
-# Step 1: Build Rust backend with cargo in project root
-echo "Step 1: Building Rust backend with cargo..."
-cd ../ || { echo "Failed to enter project root directory"; exit 1; }
-cargo build --release || { echo "Rust backend build failed"; exit 1; }
+docker build \
+    --build-arg CRATE_VERSION="$VERSION" \
+    -t bichon:"$VERSION" \
+    -f ./Dockerfile \
+    ..
 
-# Step 2: Back to docker directory
-echo "Step 2: Returning to docker directory..."
-cd docker || { echo "Failed to enter docker directory"; exit 1; }
-
-# Step 3: Extract version from Cargo.toml
-VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' ../Cargo.toml)
-echo "Step 3: Extracted version: $VERSION"
-
-# Step 4: Copy the compiled RustMailer binary to current directory (docker/)
-cp ../target/release/bichon-server .
-echo "Step 4: Copied bichon-server binary"
-
-# Step 5: Build Docker image with version tag
-sudo docker build --build-arg CRATE_VERSION=$VERSION -t bichon:$VERSION .
-echo "Step 5: Built Docker image with tag bichon:$VERSION"
-
-# Step 6: Tag local image for Docker Hub
-docker tag bichon:$VERSION billydong/bichon:$VERSION
-echo "Step 6: Tagged image as billydong/bichon:$VERSION"
+docker tag bichon:"$VERSION" billydong/bichon:"$VERSION"
+echo "Tagged billydong/bichon:$VERSION"


### PR DESCRIPTION
I noticed that the [dockerhub image](https://hub.docker.com/r/rustmailer/bichon) is only 53 MB in size.

While the github Dockerfile is built ubuntu which tends to be 250+ MB.  I think the image on Dockerhub is not built with the [Dockerfile on github](https://github.com/rustmailer/bichon/blob/main/docker/Dockerfile).

The [build.sh](https://github.com/rustmailer/bichon/blob/main/docker/build.sh) was compiling the code outside of the container.  I moved the build into the [Dockerfile](https://github.com/fama/bichon/blob/main/docker/Dockerfile). 
Using the two stage build, the final image is kept as lean as possible.

Summary:
- Replaces the pre-built binary copy approach with a proper two-stage Docker build
- Stage 1 (rust:slim-bookworm): installs Node/pnpm, builds the frontend, then compiles the Rust binary with cargo build --release
- Stage 2 (debian:bookworm-slim): copies only the compiled binaries into a minimal runtime image, keeping the final image
- Simplifies build.sh — no more manual binary copying; just docker build + tag