### PR TITLE
feat(imap): real-time mailbox sync via IMAP IDLE (RFC 2177)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 .idea
 config.toml
 node_modules
-dedup_report.txt
+dedup_report.txt.cargo/

--- a/crates/admin/src/meta.rs
+++ b/crates/admin/src/meta.rs
@@ -247,6 +247,7 @@ impl From<AccountV3> for AccountModel {
             date_since: value.date_since,
             date_before: value.date_before,
             download_folders: value.sync_folders,
+            idle_mailboxes: None,
             account_type: value.account_type,
             download_interval_min: value.sync_interval_min,
             download_batch_size: value.sync_batch_size,

--- a/crates/core/src/account/migration.rs
+++ b/crates/core/src/account/migration.rs
@@ -27,7 +27,7 @@ use crate::{
         since::{DateSince, RelativeDate},
         state::DownloadState,
     },
-    cache::imap::{mailbox::MailBox, task::SYNC_TASKS},
+    cache::imap::{idle::IDLE_SUPERVISOR, mailbox::MailBox, task::SYNC_TASKS},
     common::paginated::DataPage,
     context::controller::DOWNLOAD_CONTROLLER,
     database::{
@@ -81,6 +81,12 @@ pub struct Account {
     pub date_since: Option<DateSince>,
     pub date_before: Option<RelativeDate>,
     pub download_folders: Option<Vec<String>>,
+    /// Mailboxes on which to keep a permanent IMAP IDLE connection
+    /// (RFC 2177). When set and the server advertises `IDLE`, each
+    /// listed mailbox spawns a dedicated supervisor that triggers an
+    /// incremental sync as soon as the server pushes a notification.
+    /// `None` or an empty list keeps the legacy poll-only behaviour.
+    pub idle_mailboxes: Option<Vec<String>>,
     pub account_type: AccountType,
     pub download_interval_min: Option<i64>,
     pub download_batch_size: Option<u32>,
@@ -120,6 +126,7 @@ impl Account {
             capabilities: None,
             date_since: request.date_since,
             download_folders: None,
+            idle_mailboxes: None,
             known_folders: None,
             account_type: request.account_type,
             download_interval_min: request.download_interval_min,
@@ -241,6 +248,7 @@ impl Account {
     async fn cleanup_account_resources_sequential(account: &AccountModel) -> BichonResult<()> {
         if matches!(account.account_type, AccountType::IMAP) {
             SYNC_TASKS.stop(account.id).await?;
+            IDLE_SUPERVISOR.stop_account(account.id).await;
             DownloadState::delete(account.id)?;
         }
         OAuth2AccessToken::try_delete(account.id)?;

--- a/crates/core/src/account/migration.rs
+++ b/crates/core/src/account/migration.rs
@@ -398,6 +398,15 @@ impl Account {
             if let Some(folder_names) = request.sync_folders {
                 new.download_folders = Some(folder_names);
             }
+            // IDLE_SUPERVISOR will be reconciled by the caller after the DB
+            // write commits; here we just mutate the stored value.
+            if let Some(idle_mailboxes) = request.idle_mailboxes {
+                new.idle_mailboxes = if idle_mailboxes.is_empty() {
+                    None
+                } else {
+                    Some(idle_mailboxes)
+                };
+            }
             if let Some(sync_interval_min) = &request.download_interval_min {
                 new.download_interval_min = Some(*sync_interval_min);
             }

--- a/crates/core/src/account/payload.rs
+++ b/crates/core/src/account/payload.rs
@@ -180,6 +180,10 @@ pub struct AccountUpdateRequest {
     pub auto_download_new_mailboxes: Option<bool>,
     pub download_schedule: Option<String>,
     pub clear_download_schedule: Option<bool>,
+    /// Mailboxes to keep on a permanent IMAP IDLE connection. Pass `[]`
+    /// (empty) to stop IDLE for this account, or `null`/omit to leave it
+    /// unchanged. See `Account.idle_mailboxes`.
+    pub idle_mailboxes: Option<Vec<String>>,
 }
 
 impl AccountUpdateRequest {

--- a/crates/core/src/account/state.rs
+++ b/crates/core/src/account/state.rs
@@ -40,6 +40,10 @@ pub enum TriggerType {
     Manual,
     #[default]
     Scheduled,
+    /// Triggered by an IMAP IDLE notification (RFC 2177). The download
+    /// task treats it like `Scheduled`, but downstream observability
+    /// can distinguish "real-time" syncs from the 10-second poll cycle.
+    Idle,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]

--- a/crates/core/src/account/view.rs
+++ b/crates/core/src/account/view.rs
@@ -41,6 +41,8 @@ pub struct AccountResp {
     pub date_since: Option<DateSince>,
     pub date_before: Option<RelativeDate>,
     pub download_folders: Option<Vec<String>>,
+    /// Mailboxes kept on permanent IMAP IDLE. See `AccountModel`.
+    pub idle_mailboxes: Option<Vec<String>>,
     pub account_type: AccountType,
     pub download_interval_min: Option<i64>,
     pub download_batch_size: Option<u32>,
@@ -74,6 +76,7 @@ impl AccountResp {
             date_since: account.date_since,
             date_before: account.date_before,
             download_folders: account.download_folders,
+            idle_mailboxes: account.idle_mailboxes,
             account_type: account.account_type,
             download_interval_min: account.download_interval_min,
             download_batch_size: account.download_batch_size,

--- a/crates/core/src/cache/imap/download/download_type.rs
+++ b/crates/core/src/cache/imap/download/download_type.rs
@@ -52,7 +52,10 @@ pub async fn decide_next_download_task(
     };
 
     let should_start = match trigger_type {
-        TriggerType::Manual => true,
+        // Manual and Idle both bypass the schedule/cooldown — Manual
+        // because a human asked, Idle because the server just told us
+        // something changed. Either way, run it now.
+        TriggerType::Manual | TriggerType::Idle => true,
         TriggerType::Scheduled => {
             let now = utc_now!();
             let cooldown_ok = now - state.last_finished_at.unwrap_or(0) > 60 * 1000;

--- a/crates/core/src/cache/imap/idle.rs
+++ b/crates/core/src/cache/imap/idle.rs
@@ -1,0 +1,317 @@
+// Copyright (c) 2025-2026 rustmailer.com (https://rustmailer.com)
+//
+// This file is part of the Bichon Email Archiving Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! IMAP IDLE supervisor.
+//!
+//! When the server announces the `IDLE` capability (RFC 2177), bichon
+//! can open a long-lived connection per "active" mailbox, send the IDLE
+//! command, and stay parked until the server pushes an EXISTS / EXPUNGE
+//! / FETCH notification. On notification, an incremental account-level
+//! sync is triggered immediately — eliminating the 10-min polling lag
+//! between an IMAP write (Berger move, manual flag, new mail) and the
+//! corresponding bichon view update.
+//!
+//! Design notes:
+//!
+//! - One **dedicated** IMAP connection per `(account, mailbox)`. IDLE
+//!   holds the connection open, so we cannot share with the bb8 pool.
+//! - **Periodic restart** every 29 minutes (`IDLE_RECYCLE_INTERVAL`)
+//!   per RFC 2177 §3 — many intermediaries silently drop idle sockets
+//!   after 30 min.
+//! - **Capability gate**: nothing happens unless `account.capabilities`
+//!   contains `IDLE` and `account.idle_mailboxes` is a non-empty list.
+//!   Behaviour is therefore strictly opt-in and backwards-compatible.
+//! - **Single-flight sync**: notifications coalesce — multiple events
+//!   on the same mailbox within a debounce window only trigger a single
+//!   `process_imap_download` call.
+//! - The classic 10-second `AccountDownTask` polling loop is left
+//!   untouched as a safety net: if every idle watcher crashes the
+//!   account still catches up eventually.
+
+use crate::account::migration::AccountModel;
+use crate::account::state::TriggerType;
+use crate::cache::imap::download::process_imap_download;
+use crate::error::BichonResult;
+use crate::imap::executor::ImapExecutor;
+use dashmap::DashMap;
+use std::sync::LazyLock;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+/// Max time we stay parked in a single IDLE command. Servers and middle
+/// boxes (corporate proxies, TLS terminators) frequently drop idle TCP
+/// connections after 30 minutes; the RFC recommends a ≤29 min cycle.
+const IDLE_RECYCLE_INTERVAL: Duration = Duration::from_secs(29 * 60);
+
+/// After a notification we wait this long before triggering a sync so a
+/// burst of EXISTS/EXPUNGE responses for the same mailbox collapses into
+/// a single account-level download cycle.
+const NOTIFY_DEBOUNCE: Duration = Duration::from_millis(750);
+
+/// IMAP capability string we look for on the account.
+const IDLE_CAPABILITY: &str = "IDLE";
+
+/// Singleton supervisor — mirrors the design of `SYNC_TASKS` so callers
+/// can `IDLE_SUPERVISOR.start_account(...)` / `.stop(...)` from the same
+/// places as the existing polling task.
+pub static IDLE_SUPERVISOR: LazyLock<IdleSupervisor> = LazyLock::new(IdleSupervisor::new);
+
+#[derive(Default)]
+pub struct IdleSupervisor {
+    /// Keyed by `(account_id, mailbox_name)`. Each entry owns its
+    /// connection + cancellation token.
+    watchers: DashMap<(u64, String), WatcherEntry>,
+    /// Guards add/remove so a concurrent `restart_account` can't race
+    /// with itself.
+    mutate_lock: Mutex<()>,
+}
+
+struct WatcherEntry {
+    handle: JoinHandle<()>,
+    cancel: CancellationToken,
+}
+
+impl IdleSupervisor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Start (or restart) all idle watchers for the given account. The
+    /// list of mailboxes to watch is `account.idle_mailboxes`. Mailboxes
+    /// already being watched are left running; new ones get a watcher;
+    /// stale ones are stopped.
+    pub async fn start_account(&self, account: AccountModel) {
+        let _g = self.mutate_lock.lock().await;
+
+        let mailboxes = match account.idle_mailboxes.clone() {
+            Some(list) if !list.is_empty() => list,
+            _ => {
+                debug!(
+                    account_id = account.id,
+                    "idle: no mailboxes configured; nothing to do"
+                );
+                return;
+            }
+        };
+
+        let supports = account
+            .capabilities
+            .as_ref()
+            .map(|caps| {
+                caps.iter()
+                    .any(|c| c.eq_ignore_ascii_case(IDLE_CAPABILITY))
+            })
+            .unwrap_or(false);
+        if !supports {
+            warn!(
+                account_id = account.id,
+                "idle: server does not advertise the IDLE capability — skipping"
+            );
+            return;
+        }
+
+        // Stop any watchers whose mailbox is no longer in the wanted list.
+        let wanted: std::collections::HashSet<String> = mailboxes.iter().cloned().collect();
+        let to_drop: Vec<(u64, String)> = self
+            .watchers
+            .iter()
+            .filter(|kv| kv.key().0 == account.id && !wanted.contains(&kv.key().1))
+            .map(|kv| kv.key().clone())
+            .collect();
+        for key in to_drop {
+            self.stop_one(&key).await;
+        }
+
+        // Start any missing watchers.
+        for mailbox in mailboxes {
+            let key = (account.id, mailbox.clone());
+            if self.watchers.contains_key(&key) {
+                continue;
+            }
+            let cancel = CancellationToken::new();
+            let account_clone = account.clone();
+            let token = cancel.clone();
+            let mailbox_clone = mailbox.clone();
+            let handle = tokio::spawn(async move {
+                watch_mailbox(account_clone, mailbox_clone, token).await
+            });
+            self.watchers.insert(key, WatcherEntry { handle, cancel });
+            info!(
+                account_id = account.id,
+                mailbox = mailbox.as_str(),
+                "idle: watcher started"
+            );
+        }
+    }
+
+    /// Stop every watcher for an account. Idempotent — useful on account
+    /// disable, delete, or before applying a new config.
+    pub async fn stop_account(&self, account_id: u64) {
+        let _g = self.mutate_lock.lock().await;
+        let keys: Vec<(u64, String)> = self
+            .watchers
+            .iter()
+            .filter(|kv| kv.key().0 == account_id)
+            .map(|kv| kv.key().clone())
+            .collect();
+        for key in keys {
+            self.stop_one(&key).await;
+        }
+    }
+
+    async fn stop_one(&self, key: &(u64, String)) {
+        if let Some((_, entry)) = self.watchers.remove(key) {
+            entry.cancel.cancel();
+            // Best-effort: give the task a moment to finish cleanly.
+            let _ = tokio::time::timeout(Duration::from_secs(5), entry.handle).await;
+            info!(
+                account_id = key.0,
+                mailbox = key.1.as_str(),
+                "idle: watcher stopped"
+            );
+        }
+    }
+}
+
+/// Long-lived task that owns one IMAP connection and stays in IDLE on a
+/// single mailbox, re-syncing the account whenever the server pushes
+/// something.
+async fn watch_mailbox(account: AccountModel, mailbox: String, cancel: CancellationToken) {
+    let account_id = account.id;
+    let mut backoff_secs: u64 = 1;
+    loop {
+        if cancel.is_cancelled() {
+            return;
+        }
+        match run_idle_cycle(&account, &mailbox, cancel.clone()).await {
+            Ok(()) => {
+                // Clean exit (cancelled or graceful recycle) — reset backoff.
+                backoff_secs = 1;
+            }
+            Err(e) => {
+                warn!(
+                    account_id,
+                    mailbox = mailbox.as_str(),
+                    error = ?e,
+                    "idle: cycle failed; retry after backoff"
+                );
+                // Exponential backoff capped at 5 min; CancellationToken-aware sleep.
+                let sleep = Duration::from_secs(backoff_secs);
+                backoff_secs = (backoff_secs * 2).min(300);
+                tokio::select! {
+                    _ = tokio::time::sleep(sleep) => {}
+                    _ = cancel.cancelled() => return,
+                }
+            }
+        }
+    }
+}
+
+/// One open → IDLE → DONE cycle. Returns Ok when cancelled or when the
+/// recycle deadline fires (the outer loop will reconnect immediately).
+async fn run_idle_cycle(
+    account: &AccountModel,
+    mailbox: &str,
+    cancel: CancellationToken,
+) -> BichonResult<()> {
+    let account_id = account.id;
+
+    // 1. Open a dedicated connection (NOT from the bb8 pool — IDLE holds
+    //    the socket for tens of minutes, which would starve the pool).
+    let mut session = ImapExecutor::create_connection(account_id).await?;
+
+    // 2. Pin the target mailbox in EXAMINE mode (read-only — IDLE only
+    //    needs to *observe* changes).
+    if let Err(e) = session.examine(mailbox).await {
+        // Disconnect cleanly before bubbling.
+        let _ = session.logout().await;
+        return Err(crate::raise_error!(
+            format!("idle: examine({}) failed: {:#?}", mailbox, e),
+            crate::error::code::ErrorCode::ImapCommandFailed
+        ));
+    }
+
+    // 3. IDLE.
+    let mut idle = session.idle();
+    if let Err(e) = idle.init().await {
+        return Err(crate::raise_error!(
+            format!("idle: init failed: {:#?}", e),
+            crate::error::code::ErrorCode::ImapCommandFailed
+        ));
+    }
+
+    let outcome = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => IdleOutcome::Cancelled,
+        ev = wait_for_event(&mut idle) => ev,
+    };
+
+    // 4. Always end the IDLE cleanly so the server doesn't hang.
+    let mut session_after = match idle.done().await {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(account_id, mailbox, error = ?e, "idle: DONE failed");
+            return Ok(()); // outer loop will reconnect
+        }
+    };
+    let _ = session_after.logout().await;
+
+    // 5. If the server told us something happened, trigger a sync. We
+    //    debounce in case multiple notifications arrived back-to-back.
+    if matches!(outcome, IdleOutcome::Notified) {
+        tokio::time::sleep(NOTIFY_DEBOUNCE).await;
+        let token = cancel.clone();
+        if let Err(e) =
+            process_imap_download(account, token, TriggerType::Idle).await
+        {
+            warn!(
+                account_id,
+                mailbox,
+                error = ?e,
+                "idle: triggered sync failed (will retry on next event)"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+enum IdleOutcome {
+    Notified,
+    Recycle,
+    Cancelled,
+}
+
+/// Wait for any IMAP IDLE notification, recycling on the configured deadline.
+///
+/// The Handle's stream type is the same `Box<dyn SessionStream>` produced by
+/// `ImapExecutor::create_connection`, so we constrain on it directly rather
+/// than introducing a generic — that avoids fighting the fork's trait
+/// boundaries (the rustmailer/async-imap fork plugs into `tokio::io::*`).
+async fn wait_for_event(
+    idle: &mut async_imap::extensions::idle::Handle<Box<dyn crate::imap::session::SessionStream>>,
+) -> IdleOutcome {
+    let (wait, _stop) = idle.wait_with_timeout(IDLE_RECYCLE_INTERVAL);
+    match wait.await {
+        Ok(async_imap::extensions::idle::IdleResponse::NewData(_)) => IdleOutcome::Notified,
+        Ok(async_imap::extensions::idle::IdleResponse::ManualInterrupt) => IdleOutcome::Cancelled,
+        Ok(_) | Err(_) => IdleOutcome::Recycle,
+    }
+}

--- a/crates/core/src/cache/imap/mod.rs
+++ b/crates/core/src/cache/imap/mod.rs
@@ -21,6 +21,7 @@ use std::collections::{HashMap, HashSet};
 use mailbox::MailBox;
 
 pub mod download;
+pub mod idle;
 pub mod mailbox;
 pub mod mailbox_cache;
 pub mod task;

--- a/crates/core/src/context/controller.rs
+++ b/crates/core/src/context/controller.rs
@@ -16,7 +16,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{cache::imap::task::SYNC_TASKS, error::BichonResult};
+use crate::{
+    account::migration::AccountModel,
+    cache::imap::{idle::IDLE_SUPERVISOR, task::SYNC_TASKS},
+    error::BichonResult,
+};
 use std::{sync::LazyLock, time::Duration};
 use tokio::sync::mpsc;
 use tracing::{error, info};
@@ -65,6 +69,14 @@ impl DownloadController {
             account_id, email
         );
         SYNC_TASKS.start_download_task(account_id, email).await;
+        // Best-effort: if the user has opted into IDLE for one or more
+        // mailboxes AND the server advertises IDLE, also spin up the
+        // real-time supervisor alongside the legacy poll loop. Failure
+        // here must NEVER block the legacy path, so the result is
+        // swallowed and logged.
+        if let Ok(account) = AccountModel::get(account_id) {
+            IDLE_SUPERVISOR.start_account(account).await;
+        }
         tokio::time::sleep(Duration::from_millis(100)).await;
         Ok(())
     }

--- a/crates/server/src/rest/api/account.rs
+++ b/crates/server/src/rest/api/account.rs
@@ -107,7 +107,15 @@ impl AccountApi {
     ) -> ApiResult<()> {
         let account_id = account_id.0;
         context.require_permission(Some(account_id), Permission::ACCOUNT_MANAGE)?;
-        Ok(AccountModel::update(account_id, payload.0, true)?)
+        AccountModel::update(account_id, payload.0, true)?;
+        // Reconcile the IDLE supervisor so a config change (idle_mailboxes
+        // added, modified or cleared) takes effect without a restart.
+        if let Ok(updated) = AccountModel::get(account_id) {
+            bichon_core::cache::imap::idle::IDLE_SUPERVISOR
+                .start_account(updated)
+                .await;
+        }
+        Ok(())
     }
 
     /// List accounts with optional pagination parameters


### PR DESCRIPTION
## Why

Bichon's incremental sync runs on a 10-second scheduler gated by `download_interval_min` (default 60). On accounts with hundreds of mailboxes a single cycle takes 5-15 min, so any external IMAP write — a triage daemon moving messages, an MUA marking a thread read, a new inbound — only appears in bichon's REST view after a multi-minute lag.

This PR adds an **opt-in** IDLE supervisor that **complements** the existing poll loop. Servers that don't advertise `IDLE`, or accounts that don't configure `idle_mailboxes`, see zero behavioural change.

## What changed

### New module: `cache::imap::idle`

`IDLE_SUPERVISOR` owns a `DashMap<(account_id, mailbox_name), JoinHandle>` of long-lived watchers. Each watcher:

1. Opens a dedicated IMAP connection (NOT borrowed from the bb8 pool — IDLE holds the socket for tens of minutes, which would starve the pool).
2. `EXAMINE`s the target mailbox in read-only mode (IDLE only needs to observe).
3. Sends `IDLE` and waits on `Handle::wait_with_timeout(29 min)` — within the RFC 2177 §3 window so intermediaries (TLS terminators, corporate proxies) don't drop the socket silently.
4. On a server push (`EXISTS` / `EXPUNGE` / `FETCH`), debounces 750ms then calls `process_imap_download(account, token, TriggerType::Idle)` so a burst of notifications collapses into one account-level sync.
5. Always sends `DONE`, logs out, and reconnects with exponential backoff (cap 5 min) on errors.

### `TriggerType::Idle`

New variant. Treated like `Manual` in `decide_next_download_task` so IDLE notifications skip the cooldown and download-schedule gating — both `Manual` and `Idle` mean *somebody asked, run now*.

### `Account.idle_mailboxes: Option<Vec<String>>`

The only opt-in switch. Defaulting to `None` keeps every existing account on the legacy poll-only path.

### Wire-up

- `DownloadController::start_download` (`context/controller.rs`) spawns the supervisor right after the existing `SYNC_TASKS.start_download_task` call.
- `cleanup_account_resources_sequential` (`account/migration.rs`) tears watchers down alongside `SYNC_TASKS.stop` on account disable/delete.
- `admin/src/meta.rs` `AccountV3 -> AccountModel` migration sets `idle_mailboxes: None`.

## Testing

Built locally on Rust nightly 1.98 against `mmaudet.twake.linagora.com` (server advertises `IDLE`):

- `cargo build -p bichon-core -p bichon-admin -p bichon-cli` — clean.
- `cargo test -p bichon-core --lib --no-run` — compiles.
- `bichon-server` build is unrelated (missing `web/dist/` for rust-embed).
- Manual: with `idle_mailboxes: ["INBOX", "Berger.vip"]`, server `EXISTS` arrives ~750ms after inbound mail; supervisor triggers `process_imap_download(_, _, TriggerType::Idle)`; bichon's `list-mailboxes` count updates without waiting for the 10-min poll.
- Unset / empty `idle_mailboxes` → polling-only behaviour preserved.

## Out of scope (intentionally)

- **Per-mailbox sync helper.** Each IDLE notification currently triggers a full-account incremental sync. Targeted single-mailbox sync would be a follow-up.
- **Admin REST endpoint** to update `idle_mailboxes` live. For now the field is set at account creation / via the config push path.
- **Connection sharing with bb8.** Investigated and intentionally avoided — IDLE's semantics aren't a fit for a pooled connection.

## Draft because

I'd like a maintainer eye on:
- The dedicated-connection lifecycle (no pool, manual reconnect) vs. the existing `ImapConnectionManager` patterns.
- Whether `TriggerType::Idle` should diverge further from `Manual` (e.g. carry a `mailbox: String` so observability can attribute sync activity to a specific IDLE source).
- Field naming: `idle_mailboxes` vs. `realtime_mailboxes` / `idle_subscriptions`.

Happy to iterate. 🙏