### PR TITLE
fix(smtp): don't clobber the IMAP-owned INBOX uid_validity on journal ingest (#297)

### DIFF
--- a/crates/smtp/src/server.rs
+++ b/crates/smtp/src/server.rs
@@ -615,26 +615,40 @@ async fn parse_email(data: &[u8], session: &Session) -> BichonResult<()> {
             return Ok(());
         }
     };
-    let mailbox = MailBox {
-        id: create_hash(rcpt.id, "INBOX"),
-        account_id: rcpt.id,
-        name: "INBOX".into(),
-        delimiter: Some("/".to_string()),
-        attributes: vec![Attribute {
-            attr: AttributeEnum::Extension,
-            extension: Some("CreatedByBichon".into()),
-        }],
-        exists: 0,
-        unseen: None,
-        uid_next: None,
-        uid_validity: None,
-        highest_uid: None,
-    };
-    let mailbox_id = mailbox.id;
+    let mailbox_id = create_hash(rcpt.id, "INBOX");
 
-    if let Err(e) = MailBox::batch_upsert(&[mailbox]) {
-        tracing::error!("SMTP: Failed to upsert mailbox for {}: {:?}", rcpt.email, e);
-        return Err(e.into());
+    // The INBOX row is owned by the IMAP sync, which maintains `uid_validity`,
+    // `highest_uid` and `uid_next` on it. `batch_upsert` replaces the *whole*
+    // row, so blindly upserting here (with those fields = None) clobbers the
+    // IMAP-maintained state back to None. The next reconcile then sees
+    // `uid_validity` change from Some -> None, treats the mailbox as invalid,
+    // and wipes + rebuilds it — silently losing the local copy of a large
+    // mailbox when that rebuild is interrupted (see #297).
+    //
+    // We only need the row to *exist* so the journaled envelope can attach to
+    // it, so create it only when it is missing and otherwise leave the
+    // IMAP-owned row untouched.
+    if MailBox::find_mailbox(rcpt.id, mailbox_id)?.is_none() {
+        let mailbox = MailBox {
+            id: mailbox_id,
+            account_id: rcpt.id,
+            name: "INBOX".into(),
+            delimiter: Some("/".to_string()),
+            attributes: vec![Attribute {
+                attr: AttributeEnum::Extension,
+                extension: Some("CreatedByBichon".into()),
+            }],
+            exists: 0,
+            unseen: None,
+            uid_next: None,
+            uid_validity: None,
+            highest_uid: None,
+        };
+
+        if let Err(e) = MailBox::batch_upsert(&[mailbox]) {
+            tracing::error!("SMTP: Failed to upsert mailbox for {}: {:?}", rcpt.email, e);
+            return Err(e.into());
+        }
     }
 
     extract_envelope_from_smtp(data, rcpt.id, mailbox_id)


### PR DESCRIPTION
## Summary

Fixes the silent INBOX data loss reported and diagnosed in #297.

When SMTP journaling ingests a message, `parse_email()` (`crates/smtp/src/server.rs`) upserts the account's INBOX `MailBox` row so the journaled envelope has a row to attach to. It built that row with `uid_validity` / `highest_uid` / `uid_next` = `None` and called `MailBox::batch_upsert`, which **replaces the whole row** (memdb `upsert` stores the serialized value under the key — no field merge).

The catch: the INBOX row id is `create_hash(account_id, "INBOX")` — the **same id the IMAP sync maintains**. So every journaled delivery reset the IMAP-maintained `uid_validity` back to `None`.

On the next reconcile, `crates/core/src/cache/imap/download/flow.rs` evaluates `local_mailbox.uid_validity != Some(remote_uid_validity)`, which is now `true`, so the mailbox is treated as invalid and goes down the **reset → wipe → rebuild** path. For a large, UID-sparse INBOX whose rebuild is interrupted (`Scheduled task skipped (Previous sync still active)`), the local copy is destroyed and never restored — the incremental fetch resumes at `UID highest_uid+1:*`, past every existing message.

### Evidence (from #297)

The reporter inspected their live memdb (`storage/memdb/snapshot.json`). The affected account — the one mailbox that is both IMAP-synced and an active journaling target — had its INBOX row stored as:

```json
{ "name": "INBOX", "uid_validity": null, "highest_uid": null, "uid_next": null }
```

…despite the INBOX holding ~17,885 envelopes. It was the **only** all-`null` row; every other account's INBOX, and that same account's own `Sent` folder, had `uid_validity` populated. That all-`null` triple is exactly what `parse_email()` writes.

## The fix

Only create the INBOX row when it doesn't already exist; otherwise leave the IMAP-owned row untouched. The journaling path only needs the row to **exist** so the envelope can attach to it — it doesn't need to (and shouldn't) overwrite the sync metadata.

```rust
let mailbox_id = create_hash(rcpt.id, "INBOX");
if MailBox::find_mailbox(rcpt.id, mailbox_id)?.is_none() {
    // ...construct + batch_upsert the placeholder INBOX row...
}
```

## Testing

⚠️ **Untested — please verify.** I was not able to build/run the Bichon workspace in my environment, so this change is offered as a reviewed-and-reasoned patch, not a verified one. It's a small, localized change (guard an existing upsert behind a not-exists check using the existing `MailBox::find_mailbox`), but a maintainer build + a test that asserts "SMTP ingest preserves an existing INBOX row's `uid_validity`" would be the right gate before merge.

## Recommended additional hardening (not in this PR)

These are defense-in-depth for any *other* way `uid_validity` could become `None` (e.g. legacy rows, or the `AccountType::NoSync` import path in `crates/core/src/account/import` which also writes the INBOX row with `uid_validity: None`):

1. **Treat `local uid_validity == None` as "first sight"** in `reconcile_mailboxes` (`flow.rs`): adopt the remote value and do a full `UID FETCH 1:*`, rather than the destructive delete-and-rebuild branch. i.e. only reset when `matches!(local.uid_validity, Some(v) if v != remote)`.
2. **Make the reset atomic** in `crates/core/src/cache/imap/rebuild.rs`: don't `delete_mailbox_envelopes` before a successful refetch, and persist the resolved `uid_validity` in the same successful unit — today it's deferred to the end of `reconcile_mailboxes`, so a `?`/cancellation between the delete and the persist leaves the mailbox emptied with `uid_validity` still `None`, which is what makes the loss *stick* instead of self-healing.

Closes #297.
