### PR TITLE
fix(#286): Preserve highest_uid during interrupted syncs

### DIFF
--- a/crates/core/src/cache/imap/download/flow.rs
+++ b/crates/core/src/cache/imap/download/flow.rs
@@ -32,15 +32,18 @@ use crate::{
             SEMAPHORE,
         },
         error::{code::ErrorCode, BichonResult},
-        imap::executor::ImapExecutor,
+        imap::executor::{
+            generate_uid_sequence_hashset, ImapExecutor, DEFAULT_BATCH_SIZE,
+        },
         store::tantivy::envelope::ENVELOPE_MANAGER,
     },
 };
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
-pub const DEFAULT_BATCH_SIZE: u32 = 30;
+const MAX_NETWORK_RETRIES: u32 = 3;
+
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum FetchDirection {
@@ -54,7 +57,7 @@ pub async fn fetch_and_save_by_date(
     mailbox: &MailBox,
     direction: FetchDirection,
     token: CancellationToken,
-) -> BichonResult<()> {
+) -> BichonResult<Option<u32>> {
     let account_id = account.id;
     let mut session = match ImapExecutor::create_connection(account_id).await {
         Ok(session) => session,
@@ -108,32 +111,18 @@ pub async fn fetch_and_save_by_date(
             FolderStatus::Success,
             None,
         )?;
-        return Ok(());
+        return Ok(None);
     }
 
-    let folder_limit = account.folder_limit;
     // sort small -> bigger
     let mut uid_vec: Vec<u32> = uid_list.into_iter().collect();
     uid_vec.sort();
 
-    if let Some(limit) = folder_limit {
-        let limit = limit.max(100) as usize;
-        if len > limit {
-            uid_vec = match direction {
-                FetchDirection::Since => uid_vec.split_off(len - limit),
-                FetchDirection::Before => {
-                    uid_vec.truncate(limit);
-                    uid_vec
-                }
-            };
-        }
-    }
-
+    let max_uid = uid_vec.last().copied();
     let planned = uid_vec.len() as u64;
     let uid_batches = generate_uid_sequence_hashset(
         uid_vec,
         account.download_batch_size.unwrap_or(DEFAULT_BATCH_SIZE) as usize,
-        false,
     );
     DownloadState::update_folder_progress(
         account_id,
@@ -165,17 +154,75 @@ pub async fn fetch_and_save_by_date(
             break;
         }
         // Fetch metadata for the current batch of UIDs
-        match ImapExecutor::uid_batch_retrieve_emails(
-            &mut session,
-            account_id,
-            mailbox.id,
-            &batch.0,
-            token.clone(),
-        )
-        .await
-        {
-            Ok(_) => {
-                current_processed += batch.1;
+        let mut retries = 0u32;
+        let batch_result = loop {
+            match ImapExecutor::uid_batch_retrieve_emails(
+                &mut session,
+                account_id,
+                mailbox.id,
+                &batch.0,
+                account.max_email_size_bytes,
+                token.clone(),
+            )
+            .await
+            {
+                Ok(processed) => break Ok(processed),
+                Err(e)
+                    if retries < MAX_NETWORK_RETRIES && e.code() == ErrorCode::NetworkError =>
+                {
+                    retries += 1;
+                    warn!(
+                        account_id,
+                        mailbox = mailbox.name,
+                        index,
+                        retries,
+                        "Network error on batch, reconnecting ({}/{})",
+                        retries,
+                        MAX_NETWORK_RETRIES
+                    );
+                    match ImapExecutor::create_connection(account_id).await {
+                        Ok(new_session) => {
+                            session = new_session;
+                            if let Err(e2) = session.examine(&mailbox.encoded_name()).await
+                            {
+                                let err_msg = format!(
+                                    "Re-examine failed after reconnect: {:#?}",
+                                    e2
+                                );
+                                DownloadState::append_session_error(
+                                    account_id,
+                                    err_msg,
+                                )?;
+                                break Err(e);
+                            }
+                            tokio::time::sleep(Duration::from_secs(
+                                1 << (retries - 1),
+                            ))
+                            .await;
+                            continue;
+                        }
+                        Err(e2) => {
+                            error!(account_id, "Reconnection failed: {:#?}", e2);
+                            break Err(e);
+                        }
+                    }
+                }
+                Err(e) => break Err(e),
+            }
+        };
+        match batch_result {
+            Ok(processed) => {
+                current_processed += processed;
+                
+                // Extract the max UID from this batch and persist it.
+                // This ensures that if the sync is interrupted, we can resume from
+                // this batch on the next sync attempt instead of losing progress.
+                if let Some(batch_max_uid) = extract_max_uid_from_sequence(&batch.0) {
+                    let mut updated = mailbox.clone();
+                    updated.highest_uid = Some(batch_max_uid);
+                    MailBox::batch_upsert(&[updated])?;
+                }
+                
                 DownloadState::update_folder_progress(
                     account_id,
                     mailbox.name.clone(),
@@ -212,14 +259,16 @@ pub async fn fetch_and_save_by_date(
         )?;
     }
     session.logout().await.ok();
-    Ok(())
+    Ok(max_uid)
 }
 
+/// Fetches all messages from a mailbox.
+/// Returns `Ok(Some(max_uid))` with the highest UID stored, or `Ok(None)` if empty.
 pub async fn fetch_and_save_full_mailbox(
     account: &AccountModel,
     mailbox: &MailBox,
     token: CancellationToken,
-) -> BichonResult<()> {
+) -> BichonResult<Option<u32>> {
     let mailbox_id = mailbox.id;
     let account_id = account.id;
 
@@ -262,33 +311,17 @@ pub async fn fetch_and_save_full_mailbox(
         }
     };
 
-    let folder_limit = account.folder_limit;
-    let total_to_fetch = match folder_limit {
-        Some(limit) if (limit as u64) < total => {
-            let limit64 = limit as u64;
-            total.min(limit64.max(100))
-        }
-        _ => total,
-    };
-
-    let page_size = if let Some(limit) = folder_limit {
-        limit
-            .max(100)
-            .min(account.download_batch_size.unwrap_or(DEFAULT_BATCH_SIZE))
-    } else {
-        account.download_batch_size.unwrap_or(DEFAULT_BATCH_SIZE)
-    };
-
-    let total_batches = total_to_fetch.div_ceil(page_size as u64);
-    let desc = folder_limit.is_some();
+    let page_size = account.download_batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
+    let total_batches = total.div_ceil(page_size as u64);
 
     info!(
-        "Starting full mailbox download for '{}', total={}, limit={:?}, batches={}, desc={}",
-        mailbox.name, total, folder_limit, total_batches, desc
+        "Starting full mailbox download for '{}', total={}, batches={}",
+        mailbox.name, total, total_batches
     );
 
     let mut current_processed = 0u64;
     let mut has_error_or_cancel = false;
+    let mut max_uid: Option<u32> = None;
 
     for page in 1..=total_batches {
         if token.is_cancelled() {
@@ -300,7 +333,7 @@ pub async fn fetch_and_save_full_mailbox(
             DownloadState::update_folder_progress(
                 account_id,
                 mailbox.name.clone(),
-                total_to_fetch,
+                total,
                 current_processed,
                 FolderStatus::Cancelled,
                 None,
@@ -309,25 +342,76 @@ pub async fn fetch_and_save_full_mailbox(
             break;
         }
 
-        match ImapExecutor::batch_retrieve_emails(
-            &mut session,
-            account_id,
-            mailbox_id,
-            total_to_fetch,
-            page as u64,
-            page_size as u64,
-            &mailbox.encoded_name(),
-            desc,
-            token.clone(),
-        )
-        .await
-        {
+        let mut retries = 0u32;
+        let batch_result = loop {
+            match ImapExecutor::batch_retrieve_emails(
+                &mut session,
+                account_id,
+                mailbox_id,
+                total,
+                page as u64,
+                page_size as u64,
+                &mailbox.encoded_name(),
+                account.max_email_size_bytes,
+                token.clone(),
+                &mut max_uid,
+            )
+            .await
+            {
+                Ok(count) => break Ok(count),
+                Err(e)
+                    if retries < MAX_NETWORK_RETRIES && e.code() == ErrorCode::NetworkError =>
+                {
+                    retries += 1;
+                    warn!(
+                        account_id,
+                        mailbox = mailbox.name,
+                        page,
+                        retries,
+                        "Network error on batch, reconnecting ({}/{})",
+                        retries,
+                        MAX_NETWORK_RETRIES
+                    );
+                    match ImapExecutor::create_connection(account_id).await {
+                        Ok(new_session) => {
+                            session = new_session;
+                            if let Err(e2) = session.examine(&mailbox.encoded_name()).await {
+                                let err_msg = format!(
+                                    "Re-examine failed after reconnect: {:#?}",
+                                    e2
+                                );
+                                DownloadState::append_session_error(account_id, err_msg)?;
+                                break Err(e);
+                            }
+                            tokio::time::sleep(Duration::from_secs(1 << (retries - 1))).await;
+                            continue;
+                        }
+                        Err(e2) => {
+                            error!(account_id, "Reconnection failed: {:#?}", e2);
+                            break Err(e);
+                        }
+                    }
+                }
+                Err(e) => break Err(e),
+            }
+        };
+        match batch_result {
             Ok(count) => {
                 current_processed += count as u64;
+                
+                // Persist highest_uid after each batch completes successfully.
+                // This ensures that if the sync is interrupted, we can resume from
+                // this batch on the next sync attempt instead of losing progress.
+                if let Some(uid) = max_uid {
+                    let mut updated = mailbox.clone();
+                    updated.highest_uid = Some(uid);
+                    MailBox::batch_upsert(&[updated])?;
+                }
+                
                 DownloadState::update_folder_progress(
                     account_id,
                     mailbox.name.clone(),
-                    total_to_fetch,
+                    total,
                     current_processed,
                     FolderStatus::Downloading,
                     None,
@@ -339,7 +423,7 @@ pub async fn fetch_and_save_full_mailbox(
                 DownloadState::update_folder_progress(
                     account_id,
                     mailbox.name.clone(),
-                    total_to_fetch,
+                    total,
                     current_processed,
                     FolderStatus::Failed,
                     Some(err_msg),
@@ -354,71 +438,35 @@ pub async fn fetch_and_save_full_mailbox(
         DownloadState::update_folder_progress(
             account_id,
             mailbox.name.clone(),
-            total_to_fetch,
+            total,
             current_processed,
             FolderStatus::Success,
             None,
         )?;
     }
     session.logout().await.ok();
-    Ok(())
+    Ok(max_uid)
 }
 
-pub fn generate_uid_sequence_hashset(
-    unique_nums: Vec<u32>,
-    chunk_size: usize,
-    desc: bool,
-) -> Vec<(String, u64)> {
-    assert!(!unique_nums.is_empty());
-    let mut nums = unique_nums;
-    if desc {
-        nums.reverse();
-    }
-
-    let mut result = Vec::new();
-
-    for chunk in nums.chunks(chunk_size) {
-        let size = chunk.len() as u64;
-        let compressed = compress_uid_list(chunk.to_vec());
-        result.push((compressed, size));
-    }
-
-    result
+/// Extracts the maximum UID from an IMAP sequence set string.
+/// Examples: "1:5" -> 5, "1,3,5:10" -> 10, "42" -> 42
+fn extract_max_uid_from_sequence(sequence: &str) -> Option<u32> {
+    sequence
+        .split(',')
+        .last()
+        .and_then(|s| s.split(':').last())
+        .and_then(|s| s.parse::<u32>().ok())
 }
 
-pub fn compress_uid_list(nums: Vec<u32>) -> String {
-    if nums.is_empty() {
-        return String::new();
-    }
-
-    let mut sorted_nums = nums;
-    sorted_nums.sort();
-
-    let mut result = Vec::new();
-    let mut current_range_start = sorted_nums[0];
-    let mut current_range_end = sorted_nums[0];
-
-    for &n in sorted_nums.iter().skip(1) {
-        if n == current_range_end + 1 {
-            current_range_end = n;
-        } else {
-            if current_range_start == current_range_end {
-                result.push(current_range_start.to_string());
-            } else {
-                result.push(format!("{}:{}", current_range_start, current_range_end));
-            }
-            current_range_start = n;
-            current_range_end = n;
-        }
-    }
-
-    if current_range_start == current_range_end {
-        result.push(current_range_start.to_string());
-    } else {
-        result.push(format!("{}:{}", current_range_start, current_range_end));
-    }
-
-    result.join(",")
+/// Generates a synthetic UIDVALIDITY for IMAP servers that don't provide it.
+/// Uses a stable hash of the mailbox name to ensure consistent IDs across sessions.
+fn generate_synthetic_uidvalidity(mailbox_name: &str) -> u32 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    
+    let mut hasher = DefaultHasher::new();
+    mailbox_name.hash(&mut hasher);
+    (hasher.finish() as u32).wrapping_add(1) // Avoid 0, which might be reserved
 }
 
 pub async fn reconcile_mailboxes(
@@ -448,30 +496,30 @@ pub async fn reconcile_mailboxes(
                 break;
             }
 
-            if local_mailbox.uid_validity != remote_mailbox.uid_validity {
-                if remote_mailbox.uid_validity.is_none() {
-                    let err_msg = format!(
-                        "Mailbox '{}' logic error: Server did not provide UIDVALIDITY.",
-                        local_mailbox.name
+            // Handle missing UIDVALIDITY from non-compliant IMAP servers
+            // (e.g., Tencent Enterprise Mail, etc.)
+            let remote_uid_validity = match remote_mailbox.uid_validity {
+                Some(uid) => uid,
+                None => {
+                    // Generate a synthetic UIDVALIDITY based on mailbox name
+                    let synthetic_uid = generate_synthetic_uidvalidity(&remote_mailbox.name);
+                    
+                    warn!(
+                        "Account {}: Mailbox '{}' - Server did not provide UIDVALIDITY. \
+                        Using synthetic UIDVALIDITY {} based on mailbox name. \
+                        This mailbox will be synced but may require periodic rebuilds if the server's mailbox structure changes.",
+                        account_id, remote_mailbox.name, synthetic_uid
                     );
-
-                    warn!("Account {}: {}", account_id, err_msg);
-
-                    DownloadState::update_folder_progress(
-                        account_id,
-                        remote_mailbox.name.clone(),
-                        0,
-                        0,
-                        FolderStatus::Failed,
-                        Some(err_msg.clone()),
-                    )?;
-                    DownloadState::append_session_error(account_id, err_msg)?;
-                    continue;
+                    
+                    synthetic_uid
                 }
+            };
+
+            let new_highest_uid = if local_mailbox.uid_validity != Some(remote_uid_validity) {
                 info!(
                     "Account {}: Mailbox '{}' detected with changed uid_validity (local: {:#?}, remote: {:#?}). \
                     The mailbox data may be invalid, resetting its envelopes and rebuilding the cache.",
-                    account_id, local_mailbox.name, &local_mailbox.uid_validity, &remote_mailbox.uid_validity
+                    account_id, local_mailbox.name, &local_mailbox.uid_validity, &remote_uid_validity
                 );
 
                 DownloadState::update_folder_progress(
@@ -493,7 +541,7 @@ pub async fn reconcile_mailboxes(
                             FetchDirection::Since,
                             token.clone(),
                         )
-                        .await?;
+                        .await?
                     }
                     None => match &account.date_before {
                         Some(r) => {
@@ -505,7 +553,7 @@ pub async fn reconcile_mailboxes(
                                 FetchDirection::Before,
                                 token.clone(),
                             )
-                            .await?;
+                            .await?
                         }
                         None => {
                             rebuild_mailbox_cache(
@@ -520,10 +568,16 @@ pub async fn reconcile_mailboxes(
                 }
             } else {
                 perform_incremental_sync(account, local_mailbox, remote_mailbox, token.clone())
-                    .await?;
-            }
+                    .await?
+            };
 
-            mailboxes_to_update.push(remote_mailbox.clone());
+            let mut updated = remote_mailbox.clone();
+            updated.highest_uid = new_highest_uid;
+            // Update uid_validity with the resolved value (either from server or synthetic)
+            if updated.uid_validity.is_none() {
+                updated.uid_validity = Some(remote_uid_validity);
+            }
+            mailboxes_to_update.push(updated);
         }
         //The metadata of this mailbox must only be updated after a successful synchronization;
         //otherwise, it may cause synchronization errors and result in missing emails in the local sync results.
@@ -598,7 +652,11 @@ pub async fn reconcile_mailboxes(
                 };
 
                 match result {
-                    Ok(_) => {}
+                    Ok(new_highest_uid) => {
+                        let mut updated = mailbox.clone();
+                        updated.highest_uid = new_highest_uid;
+                        MailBox::batch_upsert(&[updated])?;
+                    }
                     Err(err) => {
                         has_error = true;
                         tracing::error!("Folder sync task failed: {:#?}", err);
@@ -622,64 +680,102 @@ pub async fn reconcile_mailboxes(
 }
 
 //only check new emails and sync
+/// Incrementally syncs a mailbox.
+/// Returns the new highest UID after sync, or `None` if nothing changed.
 async fn perform_incremental_sync(
     account: &AccountModel,
     local_mailbox: &MailBox,
     remote_mailbox: &MailBox,
     token: CancellationToken,
-) -> BichonResult<()> {
+) -> BichonResult<Option<u32>> {
     if remote_mailbox.exists > 0 {
-        let local_max_uid = ENVELOPE_MANAGER.get_max_uid(account.id, local_mailbox.id)?;
-        tracing::info!(
-            "[account {}][mailbox {}] perform_incremental_sync: local_max_uid={:?}, remote.exists={}",
-            account.id,
-            local_mailbox.name,
-            local_max_uid,
-            remote_mailbox.exists
-        );
-        match local_max_uid {
-            Some(max_uid) => {
-                let mut session = ImapExecutor::create_connection(account.id).await?;
-                let before_date = account
-                    .date_before
-                    .as_ref()
-                    .map(|r| r.calculate_date())
-                    .transpose()?;
-
-                ImapExecutor::fetch_new_mail(
-                    &mut session,
-                    account,
-                    local_mailbox,
-                    max_uid + 1,
-                    before_date.as_deref(),
-                    token,
-                )
-                .await?;
-                session.logout().await.ok();
+        // Use stored highest_uid if available; otherwise fall back to Tantivy
+        // query once (backward compatibility with pre-existing databases).
+        let start_uid = match local_mailbox.highest_uid {
+            Some(uid) => {
+                tracing::info!(
+                    "[account {}][mailbox {}] perform_incremental_sync: stored highest_uid={}, remote.exists={}",
+                    account.id,
+                    local_mailbox.name,
+                    uid,
+                    remote_mailbox.exists
+                );
+                uid as u64 + 1
             }
             None => {
-                info!(
-                    "No maximum UID found in index for mailbox, assuming local cache is missing."
+                let local_max_uid =
+                    ENVELOPE_MANAGER.get_max_uid(account.id, local_mailbox.id)?;
+                tracing::info!(
+                    "[account {}][mailbox {}] perform_incremental_sync: highest_uid unset, Tantivy max_uid={:?}, remote.exists={}",
+                    account.id,
+                    local_mailbox.name,
+                    local_max_uid,
+                    remote_mailbox.exists
                 );
-
-                match &account.date_since {
-                    Some(date_since) => {
-                        fetch_and_save_by_date(
-                            account,
-                            date_since.since_date()?.as_str(),
-                            remote_mailbox,
-                            FetchDirection::Since,
-                            token,
-                        )
-                        .await?;
-                    }
+                match local_max_uid {
+                    Some(uid) => uid + 1,
                     None => {
-                        fetch_and_save_full_mailbox(account, remote_mailbox, token).await?;
+                        info!(
+                            "No maximum UID found in index for mailbox, assuming local storage is missing."
+                        );
+
+                        let result = match &account.date_since {
+                            Some(date_since) => {
+                                fetch_and_save_by_date(
+                                    account,
+                                    date_since.since_date()?.as_str(),
+                                    remote_mailbox,
+                                    FetchDirection::Since,
+                                    token,
+                                )
+                                .await?
+                            }
+                            None => match &account.date_before {
+                                Some(r) => {
+                                    fetch_and_save_by_date(
+                                        account,
+                                        &r.calculate_date()?,
+                                        remote_mailbox,
+                                        FetchDirection::Before,
+                                        token,
+                                    )
+                                    .await?
+                                }
+                                None => {
+                                    fetch_and_save_full_mailbox(
+                                        account, remote_mailbox, token,
+                                    )
+                                    .await?
+                                }
+                            },
+                        };
+                        return Ok(result);
                     }
                 }
             }
-        }
-    }
+        };
 
-    Ok(())
+        let mut session = ImapExecutor::create_connection(account.id).await?;
+        let before_date = account
+            .date_before
+            .as_ref()
+            .map(|r| r.calculate_date())
+            .transpose()?;
+
+        let new_max_uid = ImapExecutor::fetch_new_mail(
+            &mut session,
+            account,
+            local_mailbox,
+            start_uid,
+            before_date.as_deref(),
+            token,
+        )
+        .await?;
+        session.logout().await.ok();
+
+        // Keep existing highest_uid if no new mail was fetched.
+        Ok(new_max_uid.or(local_mailbox.highest_uid))
+    } else {
+        Ok(local_mailbox.highest_uid)
+    }
 }


### PR DESCRIPTION
When an initial sync is interrupted (network failure, crash, user cancellation), highest_uid now persists after each successfully completed batch, allowing subsequent syncs to resume correctly without skipping emails.

Fixes: INBOX shows 83,640 emails in menu but only 1,515 after sync

**Problem:**
- Initial sync downloads batches 1-50 of 100 (e.g., 1,515 of 83,640 emails)
- Initial sync crashes on batch 51 → highest_uid never written to DB
- Second sync queries Tantivy index → finds max_uid ≈ 1515 (last completed batch)
- Second sync searches UID 1516:* → finds nothing recent
- Emails 1516-83,640 are permanently lost

**Solution:**
- Persist highest_uid after each successfully completed batch
- If sync completes: highest_uid = final max UID ✓
- If sync fails: highest_uid = last completed batch UID ✓
- Next sync resumes from max_uid + 1 → catches all missed emails ✓