### PR TITLE
feat: enable glob wildcard search in text fields

### DIFF
--- a/crates/core/src/store/tantivy/attachment.rs
+++ b/crates/core/src/store/tantivy/attachment.rs
@@ -44,6 +44,7 @@ use crate::{
         model::{extract_senders, AttachmentModel},
         schema::SchemaTools,
         tokenizers::EuroTokenizer,
+        wildcard::{analyzed, build_wildcard_query, is_wildcard_query, WildcardField},
     },
 };
 
@@ -333,20 +334,27 @@ impl IndexManager {
         }
 
         if let Some(ref text) = filter.text {
-            let query_parser =
-                QueryParser::for_index(&self.index, SchemaTools::attachment_default_fields());
-
-            let query = query_parser
-                .parse_query(text)
-                .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter))?;
-            subqueries.push((Occur::Must, Box::new(query)));
+            let query = if is_wildcard_query(text) {
+                build_wildcard_query(&analyzed(&SchemaTools::attachment_default_fields()), text)?
+            } else {
+                let query_parser =
+                    QueryParser::for_index(&self.index, SchemaTools::attachment_default_fields());
+                query_parser.parse_query(text).map_err(|e| {
+                    raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter)
+                })?
+            };
+            subqueries.push((Occur::Must, query));
         }
 
         if let Some(ref subject_val) = filter.subject {
-            let query_parser = QueryParser::for_index(&self.index, vec![f.f_subject]);
-            let q = query_parser
-                .parse_query(subject_val)
-                .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter))?;
+            let q = if is_wildcard_query(subject_val) {
+                build_wildcard_query(&analyzed(&[f.f_subject]), subject_val)?
+            } else {
+                let query_parser = QueryParser::for_index(&self.index, vec![f.f_subject]);
+                query_parser.parse_query(subject_val).map_err(|e| {
+                    raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter)
+                })?
+            };
             subqueries.push((Occur::Must, q));
         }
 
@@ -371,10 +379,14 @@ impl IndexManager {
         }
 
         if let Some(from_query) = &filter.from {
-            let query_parser = QueryParser::for_index(&self.index, vec![f.f_from_text]);
-            let q = query_parser
-                .parse_query(from_query)
-                .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter))?;
+            let q = if is_wildcard_query(from_query) {
+                build_wildcard_query(&analyzed(&[f.f_from_text]), from_query)?
+            } else {
+                let query_parser = QueryParser::for_index(&self.index, vec![f.f_from_text]);
+                query_parser.parse_query(from_query).map_err(|e| {
+                    raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter)
+                })?
+            };
             subqueries.push((Occur::Must, q))
         }
 
@@ -391,12 +403,25 @@ impl IndexManager {
         }
 
         if let Some(ref name) = filter.attachment_name {
-            let query_parser =
-                QueryParser::for_index(&self.index, vec![f.f_name_text, f.f_name_exact]);
-
-            let q = query_parser
-                .parse_query(name)
-                .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter))?;
+            let q = if is_wildcard_query(name) {
+                let fields = [
+                    WildcardField {
+                        field: f.f_name_text,
+                        analyzed: true,
+                    },
+                    WildcardField {
+                        field: f.f_name_exact,
+                        analyzed: false,
+                    },
+                ];
+                build_wildcard_query(&fields, name)?
+            } else {
+                let query_parser =
+                    QueryParser::for_index(&self.index, vec![f.f_name_text, f.f_name_exact]);
+                query_parser
+                    .parse_query(name)
+                    .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter))?
+            };
             subqueries.push((Occur::Must, q));
         }
 

--- a/crates/core/src/store/tantivy/envelope.rs
+++ b/crates/core/src/store/tantivy/envelope.rs
@@ -49,6 +49,7 @@ use crate::{
             model::{extract_contacts, EnvelopeWithAttachments},
             schema::SchemaTools,
             tokenizers::EuroTokenizer,
+            wildcard::{analyzed, build_wildcard_query, is_wildcard_query, WildcardField},
         },
     },
     utc_now,
@@ -400,29 +401,39 @@ impl IndexManager {
         }
 
         if let Some(ref text) = filter.text {
-            let query_parser =
-                QueryParser::for_index(&self.index, SchemaTools::email_default_fields());
-
-            let query = query_parser
-                .parse_query(text)
-                .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter))?;
-            subqueries.push((Occur::Must, Box::new(query)));
+            let query = if is_wildcard_query(text) {
+                build_wildcard_query(&analyzed(&SchemaTools::email_default_fields()), text)?
+            } else {
+                let query_parser =
+                    QueryParser::for_index(&self.index, SchemaTools::email_default_fields());
+                query_parser.parse_query(text).map_err(|e| {
+                    raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter)
+                })?
+            };
+            subqueries.push((Occur::Must, query));
         }
 
         if let Some(ref subject_val) = filter.subject {
-            let query_parser = QueryParser::for_index(&self.index, vec![f.f_subject]);
-            let q = query_parser
-                .parse_query(subject_val)
-                .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter))?;
+            let q = if is_wildcard_query(subject_val) {
+                build_wildcard_query(&analyzed(&[f.f_subject]), subject_val)?
+            } else {
+                let query_parser = QueryParser::for_index(&self.index, vec![f.f_subject]);
+                query_parser.parse_query(subject_val).map_err(|e| {
+                    raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter)
+                })?
+            };
             subqueries.push((Occur::Must, q));
         }
 
         if let Some(ref body_val) = filter.body {
-            let query_parser = QueryParser::for_index(&self.index, vec![f.f_body]);
-
-            let q = query_parser
-                .parse_query(body_val)
-                .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter))?;
+            let q = if is_wildcard_query(body_val) {
+                build_wildcard_query(&analyzed(&[f.f_body]), body_val)?
+            } else {
+                let query_parser = QueryParser::for_index(&self.index, vec![f.f_body]);
+                query_parser.parse_query(body_val).map_err(|e| {
+                    raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter)
+                })?
+            };
             subqueries.push((Occur::Must, q));
         }
 
@@ -453,39 +464,61 @@ impl IndexManager {
             (f.f_bcc_text, &filter.bcc),
         ] {
             if let Some(ref v) = opt_value {
-                let query_parser = QueryParser::for_index(&self.index, vec![field]);
-                let q = query_parser
-                    .parse_query(v)
-                    .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter))?;
+                let q = if is_wildcard_query(v) {
+                    build_wildcard_query(&analyzed(&[field]), v)?
+                } else {
+                    let query_parser = QueryParser::for_index(&self.index, vec![field]);
+                    query_parser
+                        .parse_query(v)
+                        .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter))?
+                };
                 subqueries.push((Occur::Must, q));
             }
         }
 
         // any_recipient: OR across to, cc, bcc
         if let Some(ref v) = filter.any_recipient {
-            let mut recipient_queries: Vec<(Occur, Box<dyn Query>)> = Vec::new();
-            for field in [f.f_to_text, f.f_cc_text, f.f_bcc_text] {
-                let query_parser = QueryParser::for_index(&self.index, vec![field]);
-                if let Ok(q) = query_parser.parse_query(v) {
-                    recipient_queries.push((Occur::Should, q));
+            let recipient_fields = [f.f_to_text, f.f_cc_text, f.f_bcc_text];
+            if is_wildcard_query(v) {
+                let q = build_wildcard_query(&analyzed(&recipient_fields), v)?;
+                subqueries.push((Occur::Must, q));
+            } else {
+                let recipient_queries: Vec<(Occur, Box<dyn Query>)> = recipient_fields
+                    .into_iter()
+                    .filter_map(|field| {
+                        let query_parser = QueryParser::for_index(&self.index, vec![field]);
+                        query_parser
+                            .parse_query(v)
+                            .ok()
+                            .map(|q| (Occur::Should, q))
+                    })
+                    .collect();
+                if !recipient_queries.is_empty() {
+                    subqueries.push((Occur::Must, Box::new(BooleanQuery::new(recipient_queries))));
                 }
-            }
-            if !recipient_queries.is_empty() {
-                subqueries.push((Occur::Must, Box::new(BooleanQuery::new(recipient_queries))));
             }
         }
 
         // any_participant: OR across from, to, cc, bcc
         if let Some(ref v) = filter.any_participant {
-            let mut participant_queries: Vec<(Occur, Box<dyn Query>)> = Vec::new();
-            for field in [f.f_from_text, f.f_to_text, f.f_cc_text, f.f_bcc_text] {
-                let query_parser = QueryParser::for_index(&self.index, vec![field]);
-                if let Ok(q) = query_parser.parse_query(v) {
-                    participant_queries.push((Occur::Should, q));
+            let participant_fields = [f.f_from_text, f.f_to_text, f.f_cc_text, f.f_bcc_text];
+            if is_wildcard_query(v) {
+                let q = build_wildcard_query(&analyzed(&participant_fields), v)?;
+                subqueries.push((Occur::Must, q));
+            } else {
+                let participant_queries: Vec<(Occur, Box<dyn Query>)> = participant_fields
+                    .into_iter()
+                    .filter_map(|field| {
+                        let query_parser = QueryParser::for_index(&self.index, vec![field]);
+                        query_parser
+                            .parse_query(v)
+                            .ok()
+                            .map(|q| (Occur::Should, q))
+                    })
+                    .collect();
+                if !participant_queries.is_empty() {
+                    subqueries.push((Occur::Must, Box::new(BooleanQuery::new(participant_queries))));
                 }
-            }
-            if !participant_queries.is_empty() {
-                subqueries.push((Occur::Must, Box::new(BooleanQuery::new(participant_queries))));
             }
         }
 
@@ -506,26 +539,42 @@ impl IndexManager {
         }
 
         if let Some(ref name) = filter.attachment_name {
+            let name_is_wildcard = is_wildcard_query(name);
             if name.contains('.') {
-                let term = Term::from_field_text(f.f_attachment_name_exact, name);
-                let exact_query = TermQuery::new(term, IndexRecordOption::Basic);
+                let exact_query: Box<dyn Query> = if name_is_wildcard {
+                    build_wildcard_query(
+                        &[WildcardField {
+                            field: f.f_attachment_name_exact,
+                            analyzed: false,
+                        }],
+                        name,
+                    )?
+                } else {
+                    let term = Term::from_field_text(f.f_attachment_name_exact, name);
+                    Box::new(TermQuery::new(term, IndexRecordOption::Basic))
+                };
 
-                let query_parser =
-                    QueryParser::for_index(&self.index, vec![f.f_attachment_name_text]);
-                let q: Box<dyn Query> = query_parser
-                    .parse_query(name)
-                    .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter))?;
-                let query = BooleanQuery::new(vec![
-                    (Occur::Should, Box::new(exact_query)),
-                    (Occur::Should, Box::new(q)),
-                ]);
+                let q = if name_is_wildcard {
+                    build_wildcard_query(&analyzed(&[f.f_attachment_name_text]), name)?
+                } else {
+                    let query_parser =
+                        QueryParser::for_index(&self.index, vec![f.f_attachment_name_text]);
+                    query_parser.parse_query(name).map_err(|e| {
+                        raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter)
+                    })?
+                };
+                let query = BooleanQuery::new(vec![(Occur::Should, exact_query), (Occur::Should, q)]);
                 subqueries.push((Occur::Must, Box::new(query)));
             } else {
-                let query_parser =
-                    QueryParser::for_index(&self.index, vec![f.f_attachment_name_text]);
-                let q = query_parser
-                    .parse_query(name)
-                    .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter))?;
+                let q = if name_is_wildcard {
+                    build_wildcard_query(&analyzed(&[f.f_attachment_name_text]), name)?
+                } else {
+                    let query_parser =
+                        QueryParser::for_index(&self.index, vec![f.f_attachment_name_text]);
+                    query_parser.parse_query(name).map_err(|e| {
+                        raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter)
+                    })?
+                };
                 subqueries.push((Occur::Must, q));
             }
         }

--- a/crates/core/src/store/tantivy/mod.rs
+++ b/crates/core/src/store/tantivy/mod.rs
@@ -32,6 +32,7 @@ pub mod filter;
 pub mod model;
 pub mod schema;
 pub mod tokenizers;
+pub mod wildcard;
 
 pub fn fatal_commit(writer: &mut IndexWriter) {
     const MAX_RETRIES: usize = 3;

--- a/crates/core/src/store/tantivy/wildcard.rs
+++ b/crates/core/src/store/tantivy/wildcard.rs
@@ -1,0 +1,179 @@
+//
+// Copyright (c) 2025-2026 rustmailer.com (https://rustmailer.com)
+//
+// This file is part of the Bichon Email Archiving Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use deunicode::deunicode;
+use tantivy::query::{BooleanQuery, Occur, Query, RegexPhraseQuery, RegexQuery, TermQuery};
+use tantivy::schema::{Field, IndexRecordOption, Term};
+
+use crate::error::{code::ErrorCode, BichonResult};
+use crate::raise_error;
+
+/// A field to search against wildcard-aware free text, together with whether
+/// that field is analyzed by the "euro" tokenizer (lowercased/stemmed) or
+/// indexed as a raw/exact `STRING` field.
+#[derive(Clone, Copy)]
+pub struct WildcardField {
+    pub field: Field,
+    pub analyzed: bool,
+}
+
+/// Returns `true` if `text` contains glob wildcard characters (`*` or `?`)
+/// and therefore needs [`build_wildcard_query`] instead of tantivy's
+/// `QueryParser`, which does not support wildcard term matching.
+pub fn is_wildcard_query(text: &str) -> bool {
+    text.contains('*') || text.contains('?')
+}
+
+/// Wraps fields that are analyzed by the "euro" tokenizer for wildcard search.
+pub fn analyzed(fields: &[Field]) -> Vec<WildcardField> {
+    fields
+        .iter()
+        .map(|&field| WildcardField {
+            field,
+            analyzed: true,
+        })
+        .collect()
+}
+
+/// Splits `word` into sub-tokens the same way tantivy's `SimpleTokenizer`
+/// splits indexed text: on every non-alphanumeric boundary. `*`/`?` are kept
+/// attached to whichever sub-token they border, so wildcard patterns survive
+/// the same splitting the indexer applies at index time (e.g. `*.pdf` becomes
+/// `["*", "pdf"]`, matching how `invoice.pdf` is indexed as two terms).
+fn tokenize_word(word: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    for ch in word.chars() {
+        if ch.is_alphanumeric() || ch == '*' || ch == '?' {
+            current.push(ch);
+        } else if !current.is_empty() {
+            tokens.push(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+
+fn normalize(token: &str, analyzed: bool) -> String {
+    if analyzed {
+        deunicode(&token.to_lowercase())
+    } else {
+        token.to_string()
+    }
+}
+
+/// Converts a glob pattern (`*` = any run of characters, `?` = any single
+/// character) into a regex pattern, escaping literal runs in one pass.
+fn glob_to_regex(pattern: &str) -> String {
+    let mut regex = String::with_capacity(pattern.len() + 4);
+    let mut literal = String::new();
+    for ch in pattern.chars() {
+        match ch {
+            '*' | '?' => {
+                if !literal.is_empty() {
+                    regex.push_str(&regex::escape(&literal));
+                    literal.clear();
+                }
+                regex.push_str(if ch == '*' { ".*" } else { "." });
+            }
+            _ => literal.push(ch),
+        }
+    }
+    if !literal.is_empty() {
+        regex.push_str(&regex::escape(&literal));
+    }
+    regex
+}
+
+fn token_query(field: Field, token: &str, analyzed: bool) -> BichonResult<Box<dyn Query>> {
+    let normalized = normalize(token, analyzed);
+    if token.contains('*') || token.contains('?') {
+        let pattern = glob_to_regex(&normalized);
+        Ok(Box::new(
+            RegexQuery::from_pattern(&pattern, field)
+                .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InvalidParameter))?,
+        ))
+    } else {
+        Ok(Box::new(TermQuery::new(
+            Term::from_field_text(field, &normalized),
+            IndexRecordOption::Basic,
+        )))
+    }
+}
+
+/// Builds a query for a single whitespace-separated `word` against one field.
+///
+/// Raw/exact fields are not tokenized at index time, so `word` is matched as
+/// one term. Analyzed fields, however, are split into terms on punctuation by
+/// the "euro" tokenizer's `SimpleTokenizer`; a `word` that spans a punctuation
+/// boundary (e.g. `*@example.com`, `invoice*.pdf`) is split the same way and
+/// matched as an adjacent phrase, so it lines up with how the field's content
+/// was actually indexed.
+fn field_query(wf: &WildcardField, word: &str) -> BichonResult<Option<Box<dyn Query>>> {
+    if !wf.analyzed {
+        return token_query(wf.field, word, false).map(Some);
+    }
+
+    let tokens = tokenize_word(word);
+    match tokens.len() {
+        0 => Ok(None),
+        1 => token_query(wf.field, &tokens[0], true).map(Some),
+        _ => {
+            let patterns = tokens
+                .iter()
+                .map(|t| glob_to_regex(&normalize(t, true)))
+                .collect();
+            Ok(Some(Box::new(RegexPhraseQuery::new(wf.field, patterns))))
+        }
+    }
+}
+
+/// Builds a query over free text that may contain `*`/`?` glob wildcards.
+///
+/// Each whitespace-separated word is matched against every given field
+/// (`Occur::Should`, mirroring tantivy `QueryParser`'s default OR semantics
+/// across default fields), and words are themselves combined with
+/// `Occur::Should`.
+///
+/// Analyzed fields are lowercased and ASCII-folded to line up with how the
+/// "euro" tokenizer normalizes indexed terms; stemming, however, cannot be
+/// replicated for a wildcard pattern, so matches are approximate against
+/// stemmed forms (e.g. `run*` matches the stemmed term `run` but may miss
+/// unstemmed variants). This also means plain (non-wildcard) words lose
+/// stemming whenever they share a query string with a wildcard word, since
+/// the whole string is routed through this wildcard-aware path instead of
+/// tantivy's `QueryParser`.
+pub fn build_wildcard_query(fields: &[WildcardField], text: &str) -> BichonResult<Box<dyn Query>> {
+    let mut word_queries: Vec<(Occur, Box<dyn Query>)> = Vec::new();
+
+    for word in text.split_whitespace() {
+        let mut field_queries: Vec<(Occur, Box<dyn Query>)> = Vec::new();
+        for wf in fields {
+            if let Some(query) = field_query(wf, word)? {
+                field_queries.push((Occur::Should, query));
+            }
+        }
+        if !field_queries.is_empty() {
+            word_queries.push((Occur::Should, Box::new(BooleanQuery::new(field_queries))));
+        }
+    }
+
+    Ok(Box::new(BooleanQuery::new(word_queries)))
+}


### PR DESCRIPTION
Adds support for glob-style wildcards (* and ?) in search queries. This extends search capabilities for general text, subject lines, sender fields, and attachment names. It handles the nuances of analyzed versus exact-match fields and converts glob patterns into Tantivy's regular expressions for robust matching.