### PR TITLE
Allow web import into IMAP accounts

### DIFF
--- a/crates/core/src/import/mod.rs
+++ b/crates/core/src/import/mod.rs
@@ -374,12 +374,6 @@ fn validate_import_account(account_id: u64) -> BichonResult<AccountModel> {
             ErrorCode::InvalidParameter
         ));
     }
-    if !matches!(account.account_type, AccountType::NoSync) {
-        return Err(raise_error!(
-            "Import is only allowed for NoSync accounts. IMAP accounts sync from the server.".into(),
-            ErrorCode::InvalidParameter
-        ));
-    }
     Ok(account)
 }
 

--- a/web/src/api/import/api.ts
+++ b/web/src/api/import/api.ts
@@ -54,7 +54,7 @@ export const check_disk_space = async (): Promise<number> => {
 export const get_nosync_accounts = async (): Promise<AccountModel[]> => {
   const data = await list_accounts();
   return (data.items || []).filter(
-    (a) => a.account_type === 'NoSync' && a.enabled
+    (a) => a.enabled
   );
 };
 

--- a/web/src/api/import/api.ts
+++ b/web/src/api/import/api.ts
@@ -51,7 +51,7 @@ export const check_disk_space = async (): Promise<number> => {
   return response.data;
 };
 
-export const get_nosync_accounts = async (): Promise<AccountModel[]> => {
+export const get_import_accounts = async (): Promise<AccountModel[]> => {
   const data = await list_accounts();
   return (data.items || []).filter(
     (a) => a.enabled

--- a/web/src/features/import/index.tsx
+++ b/web/src/features/import/index.tsx
@@ -37,7 +37,7 @@ import {
 import {
   upload_import,
   get_import_progress,
-  get_nosync_accounts,
+  get_import_accounts,
   list_import_history,
   type ImportProgress,
   type ImportHistory,
@@ -121,7 +121,7 @@ export default function ImportPage() {
 
   const { data: accounts = [] } = useQuery({
     queryKey: ['nosync-accounts'],
-    queryFn: get_nosync_accounts,
+    queryFn: get_import_accounts,
     staleTime: 30_000,
   });
 


### PR DESCRIPTION
## Summary

The backend already supports mailbox resolution for IMAP accounts, but web imports were limited to NoSync accounts.

The backend already contains the required mailbox handling for IMAP accounts, so this change simply enables the existing functionality.

## Changes

- Allow selecting all enabled accounts in the web import dialog.
- Remove the backend validation that rejected IMAP accounts.
- Keep the existing mailbox behavior:
  - NoSync accounts create mailboxes automatically if necessary.
  - IMAP accounts import into existing mailboxes.

## Tested

- ✅ Frontend builds successfully.
- ✅ Backend builds successfully.
- ✅ Import into NoSync accounts still works.
- ✅ Import into IMAP accounts works.
- ✅ Existing IMAP mailboxes are listed correctly.
- ✅ Successfully imported MBOX files into IMAP folders.

## Motivation

Many users archive existing mail collections into IMAP-backed accounts.
The mailbox resolution logic was already implemented, but the UI and backend prevented using it.
This change removes that unnecessary restriction without changing the existing import logic.