### PR TITLE
Allow IMAP sync intervals as low as 1 minute

### DIFF
--- a/crates/core/src/account/payload.rs
+++ b/crates/core/src/account/payload.rs
@@ -43,7 +43,7 @@ pub struct AccountCreateRequest {
     pub date_since: Option<DateSince>,
     pub date_before: Option<RelativeDate>,
     pub account_type: AccountType,
-    #[cfg_attr(feature = "web-api", oai(validator(minimum(value = "10"))))]
+    #[cfg_attr(feature = "web-api", oai(validator(minimum(value = "1"))))]
     pub download_interval_min: Option<i64>,
     #[cfg_attr(
         feature = "web-api",
@@ -180,7 +180,7 @@ pub struct AccountUpdateRequest {
     /// Modified folders will be automatically synced on the next update.
     pub sync_folders: Option<Vec<String>>,
     /// Incremental download interval (seconds)
-    #[cfg_attr(feature = "web-api", oai(validator(minimum(value = "10"))))]
+    #[cfg_attr(feature = "web-api", oai(validator(minimum(value = "1"))))]
     pub download_interval_min: Option<i64>,
     #[cfg_attr(
         feature = "web-api",

--- a/web/src/features/accounts/components/__tests__/schema.test.ts
+++ b/web/src/features/accounts/components/__tests__/schema.test.ts
@@ -154,18 +154,18 @@ describe('Account Form Schema', () => {
   })
 
   describe('download_interval_min field', () => {
-    it('rejects value less than 10', () => {
+    it('rejects value less than 1', () => {
       const result = getAccountSchema(false, t).safeParse({
         ...validAccountData,
-        download_interval_min: 5,
+        download_interval_min: 0,
       })
       expect(result.success).toBe(false)
     })
 
-    it('accepts value of exactly 10', () => {
+    it('accepts value of exactly 1', () => {
       const result = getAccountSchema(false, t).safeParse({
         ...validAccountData,
-        download_interval_min: 10,
+        download_interval_min: 1,
       })
       expect(result.success).toBe(true)
     })

--- a/web/src/features/accounts/components/schema.ts
+++ b/web/src/features/accounts/components/schema.ts
@@ -97,8 +97,8 @@ export const getAccountSchema = (isEdit: boolean, t: (key: string) => string) =>
         invalid_type_error: t('validation.incrementalSyncMustBeNumber'),
       })
       .int()
-      .min(10, {
-        message: t('validation.incrementalSyncMustBeAtLeast10'),
+      .min(1, {
+        message: t('validation.incrementalSyncMustBeAtLeast1'),
       }),
     download_batch_size: z
       .number({

--- a/web/src/locales/ar.json
+++ b/web/src/locales/ar.json
@@ -1791,7 +1791,7 @@
     "imapHostRequired": "مُضيف IMAP مطلوب",
     "imapPortMustBeLessThan65536": "يجب أن يكون منفذ IMAP أقل من 65536",
     "imapPortMustBePositive": "يجب أن يكون منفذ IMAP عددًا صحيحًا موجبًا",
-    "incrementalSyncMustBeAtLeast10": "يجب أن يكون فاصل المزامنة التزايدية 10 دقائق على الأقل",
+    "incrementalSyncMustBeAtLeast1": "يجب أن يكون فاصل المزامنة التزايدية 1 دقيقة على الأقل",
     "incrementalSyncMustBeNumber": "يجب أن يكون فاصل المزامنة التزايدية رقمًا",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "عنوان بريد إلكتروني غير صالح",

--- a/web/src/locales/da.json
+++ b/web/src/locales/da.json
@@ -1791,7 +1791,7 @@
     "imapHostRequired": "IMAP-vært er påkrævet",
     "imapPortMustBeLessThan65536": "IMAP-port skal være mindre end 65536",
     "imapPortMustBePositive": "IMAP-port skal være et positivt heltal",
-    "incrementalSyncMustBeAtLeast10": "Inkrementelt synkroniseringsinterval skal være mindst 10 minutter",
+    "incrementalSyncMustBeAtLeast1": "Inkrementelt synkroniseringsinterval skal være mindst 1 minut",
     "incrementalSyncMustBeNumber": "Inkrementelt synkroniseringsinterval skal være et tal",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "Ugyldig e-mailadresse",

--- a/web/src/locales/de.json
+++ b/web/src/locales/de.json
@@ -1791,7 +1791,7 @@
     "imapHostRequired": "IMAP-Host ist erforderlich",
     "imapPortMustBeLessThan65536": "Der IMAP-Port muss kleiner als 65536 sein",
     "imapPortMustBePositive": "Der IMAP-Port muss eine positive ganze Zahl sein",
-    "incrementalSyncMustBeAtLeast10": "Das inkrementelle Synchronisierungsintervall muss mindestens 10 Minuten betragen",
+    "incrementalSyncMustBeAtLeast1": "Das inkrementelle Synchronisierungsintervall muss mindestens 1 Minute betragen",
     "incrementalSyncMustBeNumber": "Das inkrementelle Synchronisierungsintervall muss eine Zahl sein",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "Ungültige E-Mail-Adresse",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1807,7 +1807,7 @@
     "imapHostRequired": "IMAP host is required",
     "imapPortMustBeLessThan65536": "IMAP port must be less than 65536",
     "imapPortMustBePositive": "IMAP port must be a positive integer",
-    "incrementalSyncMustBeAtLeast10": "Incremental sync interval must be at least 10 minutes",
+    "incrementalSyncMustBeAtLeast1": "Incremental sync interval must be at least 1 minute",
     "incrementalSyncMustBeNumber": "Incremental sync interval must be a number",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "Invalid email address",

--- a/web/src/locales/es.json
+++ b/web/src/locales/es.json
@@ -1791,7 +1791,7 @@
     "imapHostRequired": "El host IMAP es obligatorio",
     "imapPortMustBeLessThan65536": "El puerto IMAP debe ser menor que 65536",
     "imapPortMustBePositive": "El puerto IMAP debe ser un número entero positivo",
-    "incrementalSyncMustBeAtLeast10": "El intervalo de sincronización incremental debe ser de al menos 10 minutos",
+    "incrementalSyncMustBeAtLeast1": "El intervalo de sincronización incremental debe ser de al menos 1 minuto",
     "incrementalSyncMustBeNumber": "El intervalo de sincronización incremental debe ser un número",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "Dirección de correo electrónico inválida",

--- a/web/src/locales/fi.json
+++ b/web/src/locales/fi.json
@@ -1791,7 +1791,7 @@
     "imapHostRequired": "IMAP-isäntä on pakollinen",
     "imapPortMustBeLessThan65536": "IMAP-portin on oltava pienempi kuin 65536",
     "imapPortMustBePositive": "IMAP-portin on oltava positiivinen kokonaisluku",
-    "incrementalSyncMustBeAtLeast10": "Lisäävän synkronoinnin välin on oltava vähintään 10 minuuttia",
+    "incrementalSyncMustBeAtLeast1": "Lisäävän synkronoinnin välin on oltava vähintään 1 minuutti",
     "incrementalSyncMustBeNumber": "Lisäävän synkronoinnin välin on oltava numero",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "Virheellinen sähköpostiosoite",

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -1791,7 +1791,7 @@
     "imapHostRequired": "L'hôte IMAP est obligatoire",
     "imapPortMustBeLessThan65536": "Le port IMAP doit être inférieur à 65536",
     "imapPortMustBePositive": "Le port IMAP doit être un entier positif",
-    "incrementalSyncMustBeAtLeast10": "L'intervalle de synchronisation incrémentielle doit être d'au moins 10 minutes",
+    "incrementalSyncMustBeAtLeast1": "L'intervalle de synchronisation incrémentielle doit être d'au moins 1 minute",
     "incrementalSyncMustBeNumber": "L'intervalle de synchronisation incrémentielle doit être un nombre",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "Adresse e-mail non valide",

--- a/web/src/locales/it.json
+++ b/web/src/locales/it.json
@@ -1791,7 +1791,7 @@
     "imapHostRequired": "L'host IMAP è obbligatorio",
     "imapPortMustBeLessThan65536": "La porta IMAP deve essere inferiore a 65536",
     "imapPortMustBePositive": "La porta IMAP deve essere un numero intero positivo",
-    "incrementalSyncMustBeAtLeast10": "L'intervallo di sincronizzazione incrementale deve essere di almeno 10 minuti",
+    "incrementalSyncMustBeAtLeast1": "L'intervallo di sincronizzazione incrementale deve essere di almeno 1 minuto",
     "incrementalSyncMustBeNumber": "L'intervallo di sincronizzazione incrementale deve essere un numero",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "Indirizzo email non valido",

--- a/web/src/locales/jp.json
+++ b/web/src/locales/jp.json
@@ -1791,7 +1791,7 @@
     "imapHostRequired": "IMAPホストは必須です",
     "imapPortMustBeLessThan65536": "IMAPポートは65536未満である必要があります",
     "imapPortMustBePositive": "IMAPポートは正の整数である必要があります",
-    "incrementalSyncMustBeAtLeast10": "増分同期間隔は10分以上である必要があります",
+    "incrementalSyncMustBeAtLeast1": "増分同期間隔は1分以上である必要があります",
     "incrementalSyncMustBeNumber": "増分同期間隔は数値である必要があります",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "無効なメールアドレスです",

--- a/web/src/locales/ko.json
+++ b/web/src/locales/ko.json
@@ -1791,7 +1791,7 @@
     "imapHostRequired": "IMAP 호스트는 필수입니다",
     "imapPortMustBeLessThan65536": "IMAP 포트는 65536보다 작아야 합니다",
     "imapPortMustBePositive": "IMAP 포트는 양의 정수여야 합니다",
-    "incrementalSyncMustBeAtLeast10": "증분 동기화 간격은 최소 10분 이상이어야 합니다",
+    "incrementalSyncMustBeAtLeast1": "증분 동기화 간격은 최소 1분 이상이어야 합니다",
     "incrementalSyncMustBeNumber": "증분 동기화 간격은 숫자여야 합니다",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "유효하지 않은 이메일 주소",

--- a/web/src/locales/nl.json
+++ b/web/src/locales/nl.json
@@ -1791,7 +1791,7 @@
     "imapHostRequired": "IMAP host is vereist",
     "imapPortMustBeLessThan65536": "IMAP poort moet kleiner zijn dan 65536",
     "imapPortMustBePositive": "IMAP poort moet een positief geheel getal zijn",
-    "incrementalSyncMustBeAtLeast10": "Incrementaal sync interval moet ten minste 10 minuten zijn",
+    "incrementalSyncMustBeAtLeast1": "Incrementaal sync interval moet ten minste 1 minuut zijn",
     "incrementalSyncMustBeNumber": "Incrementaal sync interval moet een nummer zijn",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "Ongeldig e-mailadres",

--- a/web/src/locales/no.json
+++ b/web/src/locales/no.json
@@ -1791,7 +1791,7 @@
     "imapHostRequired": "IMAP-vert er påkrevd",
     "imapPortMustBeLessThan65536": "IMAP-port må være mindre enn 65536",
     "imapPortMustBePositive": "IMAP-port må være et positivt heltall",
-    "incrementalSyncMustBeAtLeast10": "Intervall for inkrementell synkronisering må være minst 10 minutter",
+    "incrementalSyncMustBeAtLeast1": "Intervall for inkrementell synkronisering må være minst 1 minutt",
     "incrementalSyncMustBeNumber": "Intervall for inkrementell synkronisering må være et tall",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "Ugyldig e-postadresse",

--- a/web/src/locales/pl.json
+++ b/web/src/locales/pl.json
@@ -1791,7 +1791,7 @@
     "imapHostRequired": "Host IMAP jest wymagany",
     "imapPortMustBeLessThan65536": "Port IMAP musi być liczbą w przedziale 0-65535",
     "imapPortMustBePositive": "Port IMAP musi być liczbą całkowitą dodatnią",
-    "incrementalSyncMustBeAtLeast10": "Przyrostowy interwał synchronizacji musi wynosić co najmniej 10 minut",
+    "incrementalSyncMustBeAtLeast1": "Przyrostowy interwał synchronizacji musi wynosić co najmniej 1 minutę",
     "incrementalSyncMustBeNumber": "Przyrostowy interwał synchronizacji musi być liczbą",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "Niewłaściwy adres email",

--- a/web/src/locales/pt.json
+++ b/web/src/locales/pt.json
@@ -1791,7 +1791,7 @@
     "imapHostRequired": "O Host IMAP é obrigatório",
     "imapPortMustBeLessThan65536": "A Porta IMAP deve ser menor que 65536",
     "imapPortMustBePositive": "A Porta IMAP deve ser um número inteiro positivo",
-    "incrementalSyncMustBeAtLeast10": "O Intervalo de Sincronização Incremental deve ser de pelo menos 10 minutos",
+    "incrementalSyncMustBeAtLeast1": "O Intervalo de Sincronização Incremental deve ser de pelo menos 1 minuto",
     "incrementalSyncMustBeNumber": "O Intervalo de Sincronização Incremental deve ser um número",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "Endereço de email inválido",

--- a/web/src/locales/ru.json
+++ b/web/src/locales/ru.json
@@ -1791,7 +1791,7 @@
     "imapHostRequired": "IMAP хост обязателен",
     "imapPortMustBeLessThan65536": "IMAP порт должен быть меньше 65536",
     "imapPortMustBePositive": "IMAP порт должен быть положительным целым числом",
-    "incrementalSyncMustBeAtLeast10": "Интервал инкрементальной синхронизации должен быть не менее 10 минут",
+    "incrementalSyncMustBeAtLeast1": "Интервал инкрементальной синхронизации должен быть не менее 1 минуты",
     "incrementalSyncMustBeNumber": "Интервал инкрементальной синхронизации должен быть числом",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "Неверный адрес электронной почты",

--- a/web/src/locales/sv.json
+++ b/web/src/locales/sv.json
@@ -1791,7 +1791,7 @@
     "imapHostRequired": "IMAP-värd krävs",
     "imapPortMustBeLessThan65536": "IMAP-port måste vara mindre än 65536",
     "imapPortMustBePositive": "IMAP-port måste vara ett positivt heltal",
-    "incrementalSyncMustBeAtLeast10": "Intervall för inkrementell synkronisering måste vara minst 10 minuter",
+    "incrementalSyncMustBeAtLeast1": "Intervall för inkrementell synkronisering måste vara minst 1 minut",
     "incrementalSyncMustBeNumber": "Intervall för inkrementell synkronisering måste vara ett tal",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "Ogiltig e-postadress",

--- a/web/src/locales/zh-tw.json
+++ b/web/src/locales/zh-tw.json
@@ -1791,7 +1791,7 @@
     "imapHostRequired": "IMAP 主機為必填項",
     "imapPortMustBeLessThan65536": "IMAP 連接埠必須小於 65536",
     "imapPortMustBePositive": "IMAP 連接埠必須是正整數",
-    "incrementalSyncMustBeAtLeast10": "增量同步間隔必須至少為 10 分鐘",
+    "incrementalSyncMustBeAtLeast1": "增量同步間隔必須至少為 1 分鐘",
     "incrementalSyncMustBeNumber": "增量同步間隔必須是數字",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "無效的電子郵件地址",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1801,7 +1801,7 @@
     "imapHostRequired": "IMAP 主机为必填项",
     "imapPortMustBeLessThan65536": "IMAP 端口必须小于 65536",
     "imapPortMustBePositive": "IMAP 端口必须是正整数",
-    "incrementalSyncMustBeAtLeast10": "增量同步间隔必须至少为 10 分钟",
+    "incrementalSyncMustBeAtLeast1": "增量同步间隔必须至少为 1 分钟",
     "incrementalSyncMustBeNumber": "增量同步间隔必须是数字",
     "invalidCronExpression": "Invalid cron expression. Must be 6 fields: second minute hour day-of-month month day-of-week (e.g. '0 0 0 * * *')",
     "invalidEmail": "无效的电子邮件地址",


### PR DESCRIPTION
## Summary

This PR lowers the minimum allowed incremental IMAP synchronization interval from 10 minutes to 1 minute.

The scheduler already supports arbitrary minute-based intervals, but both the frontend and backend validation enforced a minimum of 10 minutes. This change only updates the validation and corresponding user-facing messages.

## Changes

- Lower backend validation from 10 to 1 minute
- Lower frontend validation from 10 to 1 minute
- Update validation tests
- Update localization strings to reflect the new minimum interval

## Compatibility

This change is fully backwards compatible.
Existing configurations continue to work unchanged.

## Testing

- Backend successfully builds (`cargo build --release`)
- Frontend successfully builds (`pnpm build`)
- Updated frontend validation tests