### PR TITLE
OpenID Connect single sign-on for the Bichon WebUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ config.toml
 node_modules
 dedup_report.txt
 crates/*/target
+.tmp/
+.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -254,6 +254,44 @@ All settings accept both CLI flags (`--bichon-http-port`) and environment variab
 |----------|---------|-------------|
 | `BICHON_ENABLE_REST_HTTPS` | `false` | Serve the API over HTTPS (requires valid certificate) |
 
+### OpenID Connect (OIDC) Single Sign-On
+
+Bichon can delegate WebUI authentication to any OIDC provider (Authentik,
+Keycloak, PocketID, Authelia, Zitadel, Dex, …) using the Authorization
+Code flow with PKCE.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BICHON_OIDC_ENABLED` | `false` | Master switch for OIDC single sign-on |
+| `BICHON_OIDC_ISSUER_URL` | — | Issuer URL. Bichon appends `/.well-known/openid-configuration` for discovery. Example: `https://auth.example.com/application/o/bichon/` |
+| `BICHON_OIDC_CLIENT_ID` | — | OAuth2 client ID registered with the IdP |
+| `BICHON_OIDC_CLIENT_SECRET` | — | OAuth2 client secret registered with the IdP |
+| `BICHON_OIDC_REDIRECT_URI` | — | Redirect URI registered with the IdP. Must resolve to `<public-url>/api/auth/oidc/callback` |
+| `BICHON_OIDC_DEFAULT_ROLE_ID` | `100200000000000` (Member) | Global role ID assigned to auto-provisioned OIDC users |
+| `BICHON_OIDC_AUTO_REDIRECT` | `false` | When true, `/sign-in` immediately redirects to the IdP. Local login stays reachable via `/sign-in?local=1` |
+
+**User resolution.** On each login Bichon looks up the user by
+`(sso_provider, sso_id)` first, then by `email`, and finally auto-provisions
+a new user with `BICHON_OIDC_DEFAULT_ROLE_ID`. The `sub` claim from the IdP
+is stored on the user and used for subsequent logins.
+
+**Signature verification.** The ID token is verified with HS256 using the
+client secret. Only signed tokens are accepted — other algorithms are
+rejected until JWKS-based asymmetric verification is added. Discovery,
+issuer, audience, expiration (with 60 s skew), and nonce are validated.
+
+**Token handoff.** After a successful callback the SPA receives a one-shot
+handoff id in the URL and POSTs it to `/api/auth/oidc/handoff` to obtain the
+WebUI access token in the response body. The access token itself is never
+placed in the URL, so it does not leak into browser history, `Referer`
+headers, or server access logs.
+
+> [!IMPORTANT]
+> Set `BICHON_OIDC_REDIRECT_URI` to the exact value you registered with the
+> IdP (including scheme, host, port, and path). The IdP rejects mismatched
+> callbacks. Behind a reverse proxy this must be the externally-reachable
+> URL, not `http://localhost:15630`.
+
 ### SMTP Server
 
 | Variable | Default | Description |
@@ -292,9 +330,10 @@ All settings accept both CLI flags (`--bichon-http-port`) and environment variab
 ### Authentication
 
 1. `POST /api/login` with username + password returns a JWT access token
-2. All `/api/v1/*` endpoints require `Authorization: Bearer <token>`
-3. Tokens expire after the configured duration (`BICHON_WEBUI_TOKEN_EXPIRATION_HOURS`, default 7 days)
-4. Long-lived API tokens can be created via WebUI or API for programmatic access
+2. `GET /api/auth/oidc/login` starts an OIDC single sign-on flow (see [OIDC](#openid-connect-oidc-single-sign-on))
+3. All `/api/v1/*` endpoints require `Authorization: Bearer <token>`
+4. Tokens expire after the configured duration (`BICHON_WEBUI_TOKEN_EXPIRATION_HOURS`, default 7 days)
+5. Long-lived API tokens can be created via WebUI or API for programmatic access
 
 ### Default Admin Account
 
@@ -690,7 +729,8 @@ No. Bichon is an **archiver**, not an email client. The optional SMTP server **r
 - [ ] Account-to-account email merge / migration
 - [ ] MCP Server for LLM-powered email search and analysis
 - [ ] S3-compatible storage backend
-- [ ] Enterprise SSO (OIDC / SAML)
+- [x] OpenID Connect (OIDC) single sign-on — see [OpenID Connect](#openid-connect-oidc-single-sign-on)
+- [ ] SAML single sign-on
 
 ## Contributing
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod mailbox;
 pub mod message;
 pub mod migrate;
 pub mod oauth2;
+pub mod oidc;
 pub mod settings;
 pub mod store;
 pub mod tasks;

--- a/crates/core/src/oidc/discovery.rs
+++ b/crates/core/src/oidc/discovery.rs
@@ -1,0 +1,112 @@
+//
+// Copyright (c) 2025-2026 rustmailer.com (https://rustmailer.com)
+//
+// This file is part of the Bichon Email Archiving Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::error::code::ErrorCode;
+use crate::error::BichonResult;
+use crate::raise_error;
+use serde::Deserialize;
+use std::sync::RwLock;
+use std::time::{Duration, Instant};
+
+const DISCOVERY_CACHE_TTL: Duration = Duration::from_secs(3600);
+const DISCOVERY_HTTP_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct OidcDiscovery {
+    pub issuer: String,
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+    pub userinfo_endpoint: Option<String>,
+    pub jwks_uri: String,
+    #[serde(default)]
+    pub id_token_signing_alg_values_supported: Vec<String>,
+    #[serde(default)]
+    pub code_challenge_methods_supported: Vec<String>,
+    #[serde(default)]
+    pub scopes_supported: Vec<String>,
+}
+
+struct CachedDiscovery {
+    doc: OidcDiscovery,
+    fetched_at: Instant,
+    issuer_url: String,
+}
+
+static DISCOVERY_CACHE: RwLock<Option<CachedDiscovery>> = RwLock::new(None);
+
+fn build_discovery_url(issuer_url: &str) -> String {
+    let base = issuer_url.trim_end_matches('/');
+    format!("{}/.well-known/openid-configuration", base)
+}
+
+pub async fn get_discovery(issuer_url: &str) -> BichonResult<OidcDiscovery> {
+    if let Ok(guard) = DISCOVERY_CACHE.read() {
+        if let Some(cached) = guard.as_ref() {
+            if cached.issuer_url == issuer_url && cached.fetched_at.elapsed() < DISCOVERY_CACHE_TTL
+            {
+                return Ok(cached.doc.clone());
+            }
+        }
+    }
+
+    let url = build_discovery_url(issuer_url);
+    let client = reqwest::Client::builder()
+        .timeout(DISCOVERY_HTTP_TIMEOUT)
+        .build()
+        .map_err(|e| {
+            raise_error!(
+                format!("Failed to build HTTP client for OIDC discovery: {}", e),
+                ErrorCode::InternalError
+            )
+        })?;
+
+    let resp = client.get(&url).send().await.map_err(|e| {
+        raise_error!(
+            format!("OIDC discovery request to {} failed: {}", url, e),
+            ErrorCode::HttpResponseError
+        )
+    })?;
+
+    if !resp.status().is_success() {
+        return Err(raise_error!(
+            format!(
+                "OIDC discovery returned non-success status {} for {}",
+                resp.status(),
+                url
+            ),
+            ErrorCode::HttpResponseError
+        ));
+    }
+
+    let doc: OidcDiscovery = resp.json().await.map_err(|e| {
+        raise_error!(
+            format!("Failed to parse OIDC discovery document: {}", e),
+            ErrorCode::HttpResponseError
+        )
+    })?;
+
+    if let Ok(mut guard) = DISCOVERY_CACHE.write() {
+        *guard = Some(CachedDiscovery {
+            doc: doc.clone(),
+            fetched_at: Instant::now(),
+            issuer_url: issuer_url.to_string(),
+        });
+    }
+
+    Ok(doc)
+}

--- a/crates/core/src/oidc/flow.rs
+++ b/crates/core/src/oidc/flow.rs
@@ -1,0 +1,273 @@
+//
+// Copyright (c) 2025-2026 rustmailer.com (https://rustmailer.com)
+//
+// This file is part of the Bichon Email Archiving Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::error::code::ErrorCode;
+use crate::error::BichonResult;
+use crate::oidc::discovery::{get_discovery, OidcDiscovery};
+use crate::oidc::id_token::{verify_and_parse, IdTokenClaims, VerifyParams};
+use crate::oidc::pending::OidcPendingEntity;
+use crate::raise_error;
+use crate::settings::cli::SETTINGS;
+use base64::Engine as _;
+use oauth2::{
+    basic::{BasicErrorResponseType, BasicTokenType},
+    AuthUrl, AuthorizationCode, Client, ClientId, ClientSecret, CsrfToken, EndpointNotSet,
+    EndpointSet, ExtraTokenFields, PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope,
+    StandardErrorResponse, StandardRevocableToken, StandardTokenIntrospectionResponse,
+    StandardTokenResponse, TokenUrl,
+};
+use rand::RngExt;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tracing::debug;
+
+fn generate_nonce() -> String {
+    let mut bytes = [0u8; 32];
+    rand::rng().fill(&mut bytes);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OidcExtraFields {
+    #[serde(default)]
+    pub id_token: Option<String>,
+}
+
+impl ExtraTokenFields for OidcExtraFields {}
+
+type OidcTokenResponse = StandardTokenResponse<OidcExtraFields, BasicTokenType>;
+type OidcErrorResponse = StandardErrorResponse<BasicErrorResponseType>;
+
+pub struct OidcConfig<'a> {
+    pub issuer_url: &'a str,
+    pub client_id: &'a str,
+    pub client_secret: &'a str,
+    pub redirect_uri: &'a str,
+}
+
+/// Extract OIDC config from SETTINGS; returns an error if OIDC is not fully configured.
+pub fn load_oidc_config() -> BichonResult<(String, String, String, String)> {
+    if !SETTINGS.bichon_oidc_enabled {
+        return Err(raise_error!(
+            "OIDC single sign-on is not enabled on this server".into(),
+            ErrorCode::PermissionDenied
+        ));
+    }
+    let issuer = SETTINGS
+        .bichon_oidc_issuer_url
+        .clone()
+        .ok_or_else(|| missing("bichon_oidc_issuer_url"))?;
+    let client_id = SETTINGS
+        .bichon_oidc_client_id
+        .clone()
+        .ok_or_else(|| missing("bichon_oidc_client_id"))?;
+    let client_secret = SETTINGS
+        .bichon_oidc_client_secret
+        .clone()
+        .ok_or_else(|| missing("bichon_oidc_client_secret"))?;
+    let redirect_uri = SETTINGS
+        .bichon_oidc_redirect_uri
+        .clone()
+        .ok_or_else(|| missing("bichon_oidc_redirect_uri"))?;
+    Ok((issuer, client_id, client_secret, redirect_uri))
+}
+
+fn missing(field: &str) -> crate::error::BichonError {
+    raise_error!(
+        format!("OIDC is enabled but '{}' is not configured", field),
+        ErrorCode::InvalidParameter
+    )
+}
+
+type OidcClient = Client<
+    OidcErrorResponse,
+    OidcTokenResponse,
+    StandardTokenIntrospectionResponse<OidcExtraFields, BasicTokenType>,
+    StandardRevocableToken,
+    StandardErrorResponse<oauth2::RevocationErrorResponseType>,
+    EndpointSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointSet,
+>;
+
+fn build_client(cfg: &OidcConfig<'_>, discovery: &OidcDiscovery) -> BichonResult<OidcClient> {
+    let auth_url = AuthUrl::new(discovery.authorization_endpoint.clone()).map_err(|e| {
+        raise_error!(
+            format!("Invalid authorization_endpoint in discovery: {}", e),
+            ErrorCode::InvalidParameter
+        )
+    })?;
+    let token_url = TokenUrl::new(discovery.token_endpoint.clone()).map_err(|e| {
+        raise_error!(
+            format!("Invalid token_endpoint in discovery: {}", e),
+            ErrorCode::InvalidParameter
+        )
+    })?;
+    let redirect = RedirectUrl::new(cfg.redirect_uri.to_string()).map_err(|e| {
+        raise_error!(
+            format!("Invalid OIDC redirect_uri configured: {}", e),
+            ErrorCode::InvalidParameter
+        )
+    })?;
+
+    let client: OidcClient = Client::new(ClientId::new(cfg.client_id.to_string()))
+        .set_client_secret(ClientSecret::new(cfg.client_secret.to_string()))
+        .set_auth_uri(auth_url)
+        .set_token_uri(token_url)
+        .set_redirect_uri(redirect);
+
+    Ok(client)
+}
+
+fn build_http_client() -> BichonResult<reqwest::Client> {
+    oauth2::reqwest::ClientBuilder::new()
+        .redirect(oauth2::reqwest::redirect::Policy::none())
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|e| {
+            raise_error!(
+                format!("Failed to build HTTP client for OIDC: {}", e),
+                ErrorCode::InternalError
+            )
+        })
+}
+
+/// Build the authorization URL and persist the pending state.
+/// Returns the URL the browser must be redirected to.
+pub async fn begin_login(redirect_after_login: Option<String>) -> BichonResult<String> {
+    let (issuer, client_id, client_secret, redirect_uri) = load_oidc_config()?;
+    let cfg = OidcConfig {
+        issuer_url: &issuer,
+        client_id: &client_id,
+        client_secret: &client_secret,
+        redirect_uri: &redirect_uri,
+    };
+
+    let discovery = get_discovery(cfg.issuer_url).await?;
+    let client = build_client(&cfg, &discovery)?;
+
+    let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+
+    let nonce = generate_nonce();
+    let request = client
+        .authorize_url(CsrfToken::new_random)
+        .add_scope(Scope::new("openid".to_string()))
+        .add_scope(Scope::new("email".to_string()))
+        .add_scope(Scope::new("profile".to_string()))
+        .set_pkce_challenge(pkce_challenge)
+        .add_extra_param("nonce", nonce.clone());
+
+    let (authorize_url, csrf_state) = request.url();
+
+    let pending = OidcPendingEntity::new(
+        csrf_state.secret().to_string(),
+        pkce_verifier.secret().to_string(),
+        nonce,
+        redirect_after_login,
+    );
+    pending.save()?;
+
+    debug!(
+        "OIDC login initiated, state={}, redirect_uri={}",
+        csrf_state.secret(),
+        cfg.redirect_uri
+    );
+
+    Ok(authorize_url.to_string())
+}
+
+/// Result of a successful OIDC callback: verified claims + the state entry
+/// (so the caller can decide where to redirect the user next).
+pub struct OidcCallbackResult {
+    pub claims: IdTokenClaims,
+    pub redirect_after_login: Option<String>,
+}
+
+/// Complete the OIDC login: exchange the code, verify the ID token, and return claims.
+pub async fn complete_login(state: &str, code: &str) -> BichonResult<OidcCallbackResult> {
+    let (issuer, client_id, client_secret, redirect_uri) = load_oidc_config()?;
+    let cfg = OidcConfig {
+        issuer_url: &issuer,
+        client_id: &client_id,
+        client_secret: &client_secret,
+        redirect_uri: &redirect_uri,
+    };
+
+    let pending = OidcPendingEntity::get(state)?.ok_or_else(|| {
+        raise_error!(
+            "OIDC state parameter is invalid or expired".into(),
+            ErrorCode::PermissionDenied
+        )
+    })?;
+
+    let discovery = get_discovery(cfg.issuer_url).await?;
+    let client = build_client(&cfg, &discovery)?;
+    let http = build_http_client()?;
+
+    // Deliberately format the token-exchange error with `Display`, not
+    // `Debug`: some oauth2 crate errors embed the raw HTTP response body,
+    // which may in edge cases echo back headers the request sent
+    // (including the client secret when using client_secret_basic).
+    let token_response = client
+        .exchange_code(AuthorizationCode::new(code.to_string()))
+        .set_pkce_verifier(PkceCodeVerifier::new(pending.code_verifier.clone()))
+        .request_async(&http)
+        .await
+        .map_err(|e| {
+            raise_error!(
+                format!("OIDC token exchange failed: {}", e),
+                ErrorCode::HttpResponseError
+            )
+        })?;
+
+    let id_token_str = token_response
+        .extra_fields()
+        .id_token
+        .as_deref()
+        .ok_or_else(|| {
+            raise_error!(
+                "OIDC token response did not contain an id_token".into(),
+                ErrorCode::HttpResponseError
+            )
+        })?;
+
+    let now_secs = chrono::Utc::now().timestamp();
+    let claims = verify_and_parse(
+        id_token_str,
+        &VerifyParams {
+            expected_issuer: &discovery.issuer,
+            expected_audience: cfg.client_id,
+            expected_nonce: &pending.nonce,
+            client_secret: cfg.client_secret.as_bytes(),
+            clock_skew_secs: 60,
+            now_secs,
+        },
+    )?;
+
+    // Best-effort cleanup; failure to delete the pending entry must not abort login.
+    if let Err(e) = OidcPendingEntity::delete(state) {
+        tracing::warn!("Failed to delete pending OIDC state '{}': {}", state, e);
+    }
+
+    Ok(OidcCallbackResult {
+        claims,
+        redirect_after_login: pending.redirect_after_login,
+    })
+}

--- a/crates/core/src/oidc/handoff.rs
+++ b/crates/core/src/oidc/handoff.rs
@@ -1,0 +1,106 @@
+//
+// Copyright (c) 2025-2026 rustmailer.com (https://rustmailer.com)
+//
+// This file is part of the Bichon Email Archiving Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! One-shot handoff of a freshly minted WebUI access token from the OIDC
+//! callback handler to the SPA.
+//!
+//! Passing the access token as a URL query parameter to the SPA would leak it
+//! into browser history, Referer headers (to images, third-party analytics,
+//! CDNs) and server access logs. Instead we store the token server-side
+//! under a short-lived, single-use handoff id, redirect the browser to
+//! `/sso-callback?handoff=<id>`, and let the SPA POST that id back to
+//! `/api/auth/oidc/handoff` to receive the token in the JSON response body.
+//!
+//! Handoff entries:
+//!   * are single-use (deleted on the first successful read),
+//!   * expire after 60 seconds,
+//!   * are keyed by 256 bits of entropy from a CSPRNG.
+
+use crate::{
+    database::{
+        batch_delete_impl, delete_impl, find_impl, insert_impl, list_all_impl, manager::DB_MANAGER,
+        MemDbModel,
+    },
+    error::BichonResult,
+    generate_token, utc_now,
+};
+use serde::{Deserialize, Serialize};
+
+const EXPIRATION_DURATION_MS: i64 = 60 * 1000;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct OidcHandoffEntity {
+    pub id: String,
+    pub access_token: String,
+    pub redirect_after_login: Option<String>,
+    pub created_at: i64,
+}
+
+impl MemDbModel for OidcHandoffEntity {
+    fn collection() -> &'static str {
+        "oidc_handoff"
+    }
+    fn key(&self) -> String {
+        self.id.clone()
+    }
+}
+
+impl OidcHandoffEntity {
+    pub fn create(access_token: String, redirect_after_login: Option<String>) -> BichonResult<Self> {
+        let entity = Self {
+            id: generate_token!(256),
+            access_token,
+            redirect_after_login,
+            created_at: utc_now!(),
+        };
+        insert_impl(DB_MANAGER.db(), entity.clone())?;
+        Ok(entity)
+    }
+
+    /// Consume a handoff entry: return it if it exists, is not expired, and
+    /// delete it in the same call so it cannot be replayed.
+    pub fn consume(id: &str) -> BichonResult<Option<Self>> {
+        let entity = find_impl::<OidcHandoffEntity>(DB_MANAGER.db(), id)?;
+        match entity {
+            Some(entity) => {
+                delete_impl::<OidcHandoffEntity>(DB_MANAGER.db(), id)?;
+                if utc_now!() - entity.created_at > EXPIRATION_DURATION_MS {
+                    return Ok(None);
+                }
+                Ok(Some(entity))
+            }
+            None => Ok(None),
+        }
+    }
+
+    pub fn clean() -> BichonResult<()> {
+        let all = list_all_impl::<OidcHandoffEntity>(DB_MANAGER.db())?;
+        let now = utc_now!();
+        let to_delete: Vec<String> = all
+            .into_iter()
+            .filter(|e| now - e.created_at > EXPIRATION_DURATION_MS)
+            .map(|e| e.id)
+            .collect();
+        if !to_delete.is_empty() {
+            batch_delete_impl::<OidcHandoffEntity>(DB_MANAGER.db(), to_delete)?;
+        }
+        Ok(())
+    }
+}
+
+

--- a/crates/core/src/oidc/id_token.rs
+++ b/crates/core/src/oidc/id_token.rs
@@ -1,0 +1,211 @@
+//
+// Copyright (c) 2025-2026 rustmailer.com (https://rustmailer.com)
+//
+// This file is part of the Bichon Email Archiving Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::error::code::ErrorCode;
+use crate::error::BichonResult;
+use crate::raise_error;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use ring::hmac;
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Constant-time byte-slice equality. Used for comparing security-sensitive
+/// values (nonces, tokens) where a variable-time compare would leak the
+/// value one byte at a time through timing side-channels.
+fn eq_ct(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Claims we care about for user identification. Extra claims are ignored.
+#[derive(Debug, Clone, Deserialize)]
+pub struct IdTokenClaims {
+    pub iss: String,
+    #[serde(default)]
+    pub aud: Value,
+    pub sub: String,
+    pub exp: i64,
+    #[serde(default)]
+    pub iat: Option<i64>,
+    #[serde(default)]
+    pub nonce: Option<String>,
+    #[serde(default)]
+    pub email: Option<String>,
+    #[serde(default)]
+    pub email_verified: Option<bool>,
+    #[serde(default)]
+    pub preferred_username: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub given_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Header {
+    alg: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    kid: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    typ: Option<String>,
+}
+
+pub struct VerifyParams<'a> {
+    pub expected_issuer: &'a str,
+    pub expected_audience: &'a str,
+    pub expected_nonce: &'a str,
+    /// Client secret bytes, required for HS256 verification. Ignored for other algs.
+    pub client_secret: &'a [u8],
+    /// Clock skew tolerance in seconds.
+    pub clock_skew_secs: i64,
+    /// Current unix time in seconds.
+    pub now_secs: i64,
+}
+
+fn split_jwt(token: &str) -> BichonResult<(&str, &str, &str)> {
+    let mut parts = token.split('.');
+    let header = parts.next();
+    let payload = parts.next();
+    let signature = parts.next();
+    match (header, payload, signature, parts.next()) {
+        (Some(h), Some(p), Some(s), None) => Ok((h, p, s)),
+        _ => Err(raise_error!(
+            "ID token is not a well-formed JWT (expected 3 segments)".into(),
+            ErrorCode::InvalidParameter
+        )),
+    }
+}
+
+fn b64url_decode(s: &str) -> BichonResult<Vec<u8>> {
+    URL_SAFE_NO_PAD.decode(s).map_err(|e| {
+        raise_error!(
+            format!("Failed to base64url-decode ID token segment: {}", e),
+            ErrorCode::InvalidParameter
+        )
+    })
+}
+
+fn audience_matches(claim: &Value, expected: &str) -> bool {
+    match claim {
+        Value::String(s) => s == expected,
+        Value::Array(arr) => arr.iter().any(|v| v.as_str() == Some(expected)),
+        _ => false,
+    }
+}
+
+/// Verify and parse the ID token.
+///
+/// The signature is verified for `HS256` using the OAuth client secret shared
+/// with the IdP. Any other algorithm is rejected — asymmetric verification via
+/// JWKS is intentionally not implemented yet, and silently trusting an
+/// unverified signature would enable token forgery if the IdP or the transport
+/// were ever compromised.
+///
+/// After the signature check all standard OIDC claims are validated: `iss`,
+/// `aud`, `exp` (with configurable skew), and `nonce` (constant-time compare
+/// to defeat timing attacks).
+pub fn verify_and_parse(token: &str, params: &VerifyParams<'_>) -> BichonResult<IdTokenClaims> {
+    let (h_b64, p_b64, s_b64) = split_jwt(token)?;
+
+    let header_bytes = b64url_decode(h_b64)?;
+    let header: Header = serde_json::from_slice(&header_bytes).map_err(|e| {
+        raise_error!(
+            format!("Failed to parse ID token header: {}", e),
+            ErrorCode::InvalidParameter
+        )
+    })?;
+
+    match header.alg.as_str() {
+        "HS256" => {
+            let signature = b64url_decode(s_b64)?;
+            let signing_input = format!("{}.{}", h_b64, p_b64);
+            let key = hmac::Key::new(hmac::HMAC_SHA256, params.client_secret);
+            hmac::verify(&key, signing_input.as_bytes(), &signature).map_err(|_| {
+                raise_error!(
+                    "ID token HS256 signature verification failed".into(),
+                    ErrorCode::PermissionDenied
+                )
+            })?;
+        }
+        other => {
+            return Err(raise_error!(
+                format!(
+                    "Unsupported ID token signing algorithm '{}'. Configure your \
+                     OIDC provider to use HS256, or extend Bichon with JWKS-based \
+                     verification for asymmetric algorithms.",
+                    other
+                ),
+                ErrorCode::PermissionDenied
+            ));
+        }
+    }
+
+    let payload_bytes = b64url_decode(p_b64)?;
+    let claims: IdTokenClaims = serde_json::from_slice(&payload_bytes).map_err(|e| {
+        raise_error!(
+            format!("Failed to parse ID token claims: {}", e),
+            ErrorCode::InvalidParameter
+        )
+    })?;
+
+    if claims.iss.trim_end_matches('/') != params.expected_issuer.trim_end_matches('/') {
+        return Err(raise_error!(
+            format!(
+                "ID token issuer mismatch: expected '{}', got '{}'",
+                params.expected_issuer, claims.iss
+            ),
+            ErrorCode::PermissionDenied
+        ));
+    }
+
+    if !audience_matches(&claims.aud, params.expected_audience) {
+        return Err(raise_error!(
+            "ID token audience does not include this client".into(),
+            ErrorCode::PermissionDenied
+        ));
+    }
+
+    if params.now_secs > claims.exp + params.clock_skew_secs {
+        return Err(raise_error!(
+            "ID token has expired".into(),
+            ErrorCode::PermissionDenied
+        ));
+    }
+
+    let nonce_ok = claims
+        .nonce
+        .as_deref()
+        .map(|n| eq_ct(n.as_bytes(), params.expected_nonce.as_bytes()))
+        .unwrap_or(false);
+    if !nonce_ok {
+        return Err(raise_error!(
+            "ID token nonce mismatch — possible replay attack".into(),
+            ErrorCode::PermissionDenied
+        ));
+    }
+
+    Ok(claims)
+}

--- a/crates/core/src/oidc/mod.rs
+++ b/crates/core/src/oidc/mod.rs
@@ -16,29 +16,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::common::periodic::TaskHandle;
-use crate::context::BichonTask;
-use crate::oauth2::{refresh::OAuth2RefreshTask, task::OAuth2CleanTask};
-use crate::oidc::task::OidcCleanTask;
-use crate::store::tantivy::dedup::DedupTask;
-
-pub struct PeriodicTasks {
-    tasks: Vec<TaskHandle>,
-}
-
-impl PeriodicTasks {
-    pub fn setup() -> Self {
-        let mut tasks = Vec::new();
-        tasks.push(OAuth2CleanTask::start());
-        tasks.push(OAuth2RefreshTask::start());
-        tasks.push(OidcCleanTask::start());
-        tasks.push(DedupTask::start());
-        Self { tasks }
-    }
-
-    pub async fn shutdown(self) {
-        for handle in self.tasks {
-            handle.stop().await;
-        }
-    }
-}
+pub mod discovery;
+pub mod flow;
+pub mod handoff;
+pub mod id_token;
+pub mod pending;
+pub mod task;

--- a/crates/core/src/oidc/pending.rs
+++ b/crates/core/src/oidc/pending.rs
@@ -1,0 +1,100 @@
+//
+// Copyright (c) 2025-2026 rustmailer.com (https://rustmailer.com)
+//
+// This file is part of the Bichon Email Archiving Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{
+    database::{
+        batch_delete_impl, delete_impl, find_impl, insert_impl, list_all_impl, manager::DB_MANAGER,
+        MemDbModel,
+    },
+    error::BichonResult,
+    utc_now,
+};
+use serde::{Deserialize, Serialize};
+
+const EXPIRATION_DURATION_MS: i64 = 10 * 60 * 1000;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct OidcPendingEntity {
+    pub state: String,
+    pub code_verifier: String,
+    pub nonce: String,
+    pub redirect_after_login: Option<String>,
+    pub created_at: i64,
+}
+
+impl MemDbModel for OidcPendingEntity {
+    fn collection() -> &'static str {
+        "oidc_pending"
+    }
+    fn key(&self) -> String {
+        self.state.clone()
+    }
+}
+
+impl OidcPendingEntity {
+    pub fn new(
+        state: String,
+        code_verifier: String,
+        nonce: String,
+        redirect_after_login: Option<String>,
+    ) -> Self {
+        Self {
+            state,
+            code_verifier,
+            nonce,
+            redirect_after_login,
+            created_at: utc_now!(),
+        }
+    }
+
+    pub fn save(&self) -> BichonResult<()> {
+        insert_impl(DB_MANAGER.db(), self.to_owned())
+    }
+
+    pub fn delete(state: &str) -> BichonResult<()> {
+        delete_impl::<OidcPendingEntity>(DB_MANAGER.db(), state)
+    }
+
+    pub fn clean() -> BichonResult<()> {
+        let all = list_all_impl::<OidcPendingEntity>(DB_MANAGER.db())?;
+        let now = utc_now!();
+        let to_delete: Vec<String> = all
+            .into_iter()
+            .filter(|e| now - e.created_at > EXPIRATION_DURATION_MS)
+            .map(|e| e.state)
+            .collect();
+        if !to_delete.is_empty() {
+            batch_delete_impl::<OidcPendingEntity>(DB_MANAGER.db(), to_delete)?;
+        }
+        Ok(())
+    }
+
+    pub fn get(state: &str) -> BichonResult<Option<OidcPendingEntity>> {
+        let entity = find_impl::<OidcPendingEntity>(DB_MANAGER.db(), state)?;
+        match entity {
+            Some(entity) => {
+                if utc_now!() - entity.created_at > EXPIRATION_DURATION_MS {
+                    delete_impl::<OidcPendingEntity>(DB_MANAGER.db(), state)?;
+                    return Ok(None);
+                }
+                Ok(Some(entity))
+            }
+            None => Ok(None),
+        }
+    }
+}

--- a/crates/core/src/oidc/task.rs
+++ b/crates/core/src/oidc/task.rs
@@ -1,0 +1,49 @@
+//
+// Copyright (c) 2025-2026 rustmailer.com (https://rustmailer.com)
+//
+// This file is part of the Bichon Email Archiving Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{
+    common::periodic::{PeriodicTask, TaskHandle},
+    context::BichonTask,
+    oidc::{handoff::OidcHandoffEntity, pending::OidcPendingEntity},
+};
+use std::time::Duration;
+
+const TASK_INTERVAL: Duration = Duration::from_secs(15 * 60);
+
+/// Periodic cleanup of expired OIDC pending-state and handoff entries.
+///
+/// Pending entries live for 10 minutes and handoff entries for 60 seconds,
+/// so a 15-minute cleanup interval bounds the amount of stale state kept
+/// in memdb even under an unfinished-login flood.
+pub struct OidcCleanTask;
+
+impl BichonTask for OidcCleanTask {
+    fn start() -> TaskHandle {
+        let periodic_task = PeriodicTask::new("oidc-cleanup");
+
+        let task = move |_: Option<u64>| {
+            Box::pin(async move {
+                OidcPendingEntity::clean()?;
+                OidcHandoffEntity::clean()?;
+                Ok(())
+            })
+        };
+
+        periodic_task.start(task, None, TASK_INTERVAL, false, false)
+    }
+}

--- a/crates/core/src/settings/cli.rs
+++ b/crates/core/src/settings/cli.rs
@@ -365,6 +365,28 @@ pub struct Settings {
     #[clap(long, env, help = "OpenID Connect redirect URI")]
     pub bichon_oidc_redirect_uri: Option<String>,
 
+    /// Role ID assigned to auto-provisioned OIDC users. Defaults to the built-in
+    /// Member role. Set to another built-in or custom role ID to change behaviour.
+    #[clap(
+        long,
+        env,
+        default_value_t = 100_200_000_000_000_u64,
+        help = "Global role ID assigned to auto-provisioned OIDC users (default: Member role)"
+    )]
+    pub bichon_oidc_default_role_id: u64,
+
+    /// When enabled and OIDC is configured, the sign-in page automatically
+    /// redirects the browser to the OIDC provider instead of showing the
+    /// username/password form. Users can still reach the local login by
+    /// visiting `/sign-in?local=1`.
+    #[clap(
+        long,
+        default_value = "false",
+        env,
+        help = "Automatically redirect the sign-in page to the OIDC provider"
+    )]
+    pub bichon_oidc_auto_redirect: bool,
+
     /// Maximum HTTP request body size in MB for file uploads (default: 1100 MB).
     /// Requests exceeding this limit are rejected at the framework level before
     /// the application reads the body, preventing memory exhaustion attacks.

--- a/crates/core/src/users/mod.rs
+++ b/crates/core/src/users/mod.rs
@@ -48,6 +48,60 @@ pub mod view;
 
 pub type UserModel = BichonUserV2;
 
+fn derive_username_base(email: &str, display_name: Option<&str>) -> String {
+    if let Some(name) = display_name.map(str::trim).filter(|s| !s.is_empty()) {
+        let sanitized: String = name
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect();
+        if !sanitized.is_empty() {
+            return sanitized;
+        }
+    }
+    email
+        .split('@')
+        .next()
+        .unwrap_or("user")
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn allocate_unique_username(base: &str) -> BichonResult<String> {
+    let base = if base.is_empty() { "user" } else { base };
+    let base_owned = base.to_string();
+    let candidate_taken = |candidate: &str| -> BichonResult<bool> {
+        let c = candidate.to_string();
+        let existing = filter_impl::<UserModel, _>(DB_MANAGER.db(), move |u| u.username == c)?;
+        Ok(existing.into_iter().next().is_some())
+    };
+    if !candidate_taken(&base_owned)? {
+        return Ok(base_owned);
+    }
+    for i in 2..1000 {
+        let candidate = format!("{}{}", base_owned, i);
+        if !candidate_taken(&candidate)? {
+            return Ok(candidate);
+        }
+    }
+    Err(raise_error!(
+        "Failed to allocate a unique username for auto-provisioned OIDC user".into(),
+        ErrorCode::InternalError
+    ))
+}
+
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct LoginResult {
     pub success: bool,
@@ -338,6 +392,77 @@ impl BichonUserV2 {
 
     pub fn find(user_id: u64) -> BichonResult<Option<UserModel>> {
         find_impl::<UserModel>(DB_MANAGER.db(), &user_id.to_string())
+    }
+
+    /// Resolve or auto-provision a Bichon user for an OIDC login.
+    ///
+    /// Resolution order:
+    ///   1. Match on `(sso_provider, sso_id)` — same subject that logged in before.
+    ///   2. Match on `email` — bind the existing user to this SSO identity.
+    ///   3. Auto-provision a new user with the configured default global role.
+    ///
+    /// Returns the resolved/created user. The caller is expected to issue a
+    /// WebUI access token for that user.
+    pub fn find_or_provision_sso_user(
+        provider: &str,
+        subject: &str,
+        email: &str,
+        display_name: Option<&str>,
+        default_role_id: u64,
+    ) -> BichonResult<UserModel> {
+        let subject_owned = subject.to_string();
+        let provider_owned = provider.to_string();
+
+        let matches_by_sso = filter_impl::<UserModel, _>(DB_MANAGER.db(), move |u| {
+            u.sso_id.as_deref() == Some(&subject_owned)
+                && u.sso_provider.as_deref() == Some(&provider_owned)
+        })?;
+        if let Some(user) = matches_by_sso.into_iter().next() {
+            return Ok(user);
+        }
+
+        let email_owned = email.to_string();
+        let matches_by_email =
+            filter_impl::<UserModel, _>(DB_MANAGER.db(), move |u| u.email == email_owned)?;
+        if let Some(mut user) = matches_by_email.into_iter().next() {
+            let now = utc_now!();
+            user.sso_id = Some(subject.to_string());
+            user.sso_provider = Some(provider.to_string());
+            user.updated_at = now;
+            let user_clone = user.clone();
+            update_impl(DB_MANAGER.db(), &user.id.to_string(), move |_current: UserModel| {
+                Ok(user_clone.clone())
+            })?;
+            return Ok(user);
+        }
+
+        let now = utc_now!();
+        let base = derive_username_base(email, display_name);
+        let username = allocate_unique_username(&base)?;
+        let new_user = UserModel {
+            id: id!(96),
+            username,
+            email: email.to_string(),
+            password: None,
+            account_access_map: BTreeMap::new(),
+            description: Some(format!("Auto-provisioned via OIDC ({})", provider)),
+            global_roles: vec![default_role_id],
+            avatar: None,
+            created_at: now,
+            updated_at: now,
+            acl: None,
+            theme: None,
+            language: None,
+            sso_id: Some(subject.to_string()),
+            sso_provider: Some(provider.to_string()),
+        };
+
+        let user_clone = new_user.clone();
+        with_transaction(DB_MANAGER.db(), move |txn| {
+            txn.insert("users", new_user.key(), &new_user)
+                .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InternalError))
+        })?;
+        Ok(user_clone)
     }
 
     pub fn check_username_conflict(username: &str) -> BichonResult<()> {

--- a/crates/server/src/rest/mod.rs
+++ b/crates/server/src/rest/mod.rs
@@ -24,6 +24,7 @@ use crate::common::timeout::{Timeout, TIMEOUT_HEADER};
 use crate::error::handler::error_handler;
 use crate::rest::public::features::get_features;
 use crate::rest::public::login::login;
+use crate::rest::public::oidc::{oidc_callback, oidc_handoff, oidc_login};
 use crate::rest::public::status::get_status;
 use bichon_core::common::signal::SIGNAL_MANAGER;
 use bichon_core::error::code::ErrorCode;
@@ -114,6 +115,9 @@ pub fn build_routes() -> impl Endpoint {
         .nest("/api/v1/features", get(get_features))
         .nest("/api/status", get(get_status))
         .nest("/api/login", post(login))
+        .nest("/api/auth/oidc/login", get(oidc_login))
+        .nest("/api/auth/oidc/callback", get(oidc_callback))
+        .nest("/api/auth/oidc/handoff", post(oidc_handoff))
         .nest_no_strip("/api/v1", open_api_route);
 
     let app_logic = add_web_assets(app_logic);

--- a/crates/server/src/rest/public/features.rs
+++ b/crates/server/src/rest/public/features.rs
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use bichon_core::settings::cli::SETTINGS;
 use poem::{handler, web::Json, IntoResponse};
 use serde::Serialize;
 
@@ -24,13 +25,28 @@ struct FeaturesResponse {
     features: Vec<String>,
     edition: &'static str,
     version: String,
+    oidc_enabled: bool,
+    oidc_auto_redirect: bool,
 }
 
 #[handler]
 pub async fn get_features() -> impl IntoResponse {
+    let oidc_enabled = SETTINGS.bichon_oidc_enabled
+        && SETTINGS.bichon_oidc_issuer_url.is_some()
+        && SETTINGS.bichon_oidc_client_id.is_some()
+        && SETTINGS.bichon_oidc_client_secret.is_some()
+        && SETTINGS.bichon_oidc_redirect_uri.is_some();
+
+    let mut features = Vec::new();
+    if oidc_enabled {
+        features.push("oidc".to_string());
+    }
+
     Json(FeaturesResponse {
-        features: vec![],
+        features,
         edition: "community",
         version: env!("CARGO_PKG_VERSION").to_string(),
+        oidc_enabled,
+        oidc_auto_redirect: oidc_enabled && SETTINGS.bichon_oidc_auto_redirect,
     })
 }

--- a/crates/server/src/rest/public/mod.rs
+++ b/crates/server/src/rest/public/mod.rs
@@ -20,4 +20,5 @@
 pub mod features;
 pub mod login;
 pub mod oauth2;
+pub mod oidc;
 pub mod status;

--- a/crates/server/src/rest/public/oidc.rs
+++ b/crates/server/src/rest/public/oidc.rs
@@ -1,0 +1,266 @@
+//
+// Copyright (c) 2025-2026 rustmailer.com (https://rustmailer.com)
+//
+// This file is part of the Bichon Email Archiving Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use bichon_core::database::insert_impl;
+use bichon_core::database::manager::DB_MANAGER;
+use bichon_core::oidc::flow::{begin_login, complete_login};
+use bichon_core::oidc::handoff::OidcHandoffEntity;
+use bichon_core::settings::cli::SETTINGS;
+use bichon_core::token::AccessTokenModel;
+use bichon_core::users::UserModel;
+use poem::{
+    handler,
+    web::{Json, Query, Redirect},
+    IntoResponse, Response, Result,
+};
+use serde::{Deserialize, Serialize};
+use tracing::{error, warn};
+
+const OIDC_PROVIDER_ID: &str = "oidc";
+
+#[derive(Deserialize)]
+pub struct OidcLoginParams {
+    /// Optional path within the Bichon WebUI to return to after login.
+    #[serde(default)]
+    pub redirect_to: Option<String>,
+}
+
+/// Kick off the OIDC login: build the authorize URL, persist state+PKCE+nonce,
+/// then 302 the browser to the IdP.
+#[handler]
+pub async fn oidc_login(Query(params): Query<OidcLoginParams>) -> Result<Response> {
+    if !SETTINGS.bichon_oidc_enabled {
+        return Ok(Response::builder()
+            .status(http::StatusCode::NOT_FOUND)
+            .body("OIDC single sign-on is not enabled on this server"));
+    }
+
+    match begin_login(sanitize_redirect(params.redirect_to)).await {
+        Ok(url) => Ok(Redirect::temporary(url).into_response()),
+        Err(e) => {
+            error!("Failed to begin OIDC login: {}", e);
+            // Do not echo internal error details back to the browser — they
+            // may contain configuration hints useful to an attacker.
+            Ok(Response::builder()
+                .status(http::StatusCode::INTERNAL_SERVER_ERROR)
+                .body("Failed to start OIDC login. Check server logs for details."))
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct OidcCallbackParams {
+    pub state: Option<String>,
+    pub code: Option<String>,
+    pub error: Option<String>,
+    pub error_description: Option<String>,
+}
+
+/// Handle the redirect back from the IdP: exchange the code, verify the ID
+/// token, resolve/auto-provision the Bichon user, mint a WebUI access token
+/// and hand it back to the SPA.
+#[handler]
+pub async fn oidc_callback(Query(params): Query<OidcCallbackParams>) -> Result<Response> {
+    if !SETTINGS.bichon_oidc_enabled {
+        return Ok(Response::builder()
+            .status(http::StatusCode::NOT_FOUND)
+            .body("OIDC single sign-on is not enabled on this server"));
+    }
+
+    if let Some(err) = params.error {
+        let desc = params.error_description.unwrap_or_default();
+        warn!("OIDC provider returned error '{}': {}", err, desc);
+        // The full error text is user-controlled by the IdP — surface a
+        // short generic message and hand the operator the details via logs.
+        return Ok(redirect_login_error(
+            "OIDC provider rejected the login. See server logs.",
+        ));
+    }
+
+    let (state, code) = match (params.state, params.code) {
+        (Some(s), Some(c)) => (s, c),
+        _ => {
+            return Ok(redirect_login_error(
+                "OIDC callback missing required 'state' or 'code' parameter",
+            ));
+        }
+    };
+
+    let result = match complete_login(&state, &code).await {
+        Ok(r) => r,
+        Err(e) => {
+            error!("OIDC token exchange or verification failed: {}", e);
+            return Ok(redirect_login_error(
+                "OIDC login failed. See server logs for details.",
+            ));
+        }
+    };
+
+    let claims = result.claims;
+
+    let email = match claims.email.as_deref() {
+        Some(e) if !e.is_empty() => e,
+        _ => {
+            return Ok(redirect_login_error(
+                "OIDC provider did not return an email claim; cannot log in",
+            ));
+        }
+    };
+
+    let display_name = claims
+        .preferred_username
+        .as_deref()
+        .or(claims.name.as_deref())
+        .or(claims.given_name.as_deref());
+
+    let user = match UserModel::find_or_provision_sso_user(
+        OIDC_PROVIDER_ID,
+        &claims.sub,
+        email,
+        display_name,
+        SETTINGS.bichon_oidc_default_role_id,
+    ) {
+        Ok(u) => u,
+        Err(e) => {
+            error!("Failed to resolve OIDC user: {}", e);
+            return Ok(redirect_login_error(
+                "Failed to resolve Bichon user for OIDC subject. See server logs.",
+            ));
+        }
+    };
+
+    // Mint a fresh WebUI token for this session and persist it directly so we
+    // do not clobber a concurrent password login for the same user.
+    let token = AccessTokenModel::new_webui_token(user.id);
+    let token_str = token.token.clone();
+    if let Err(e) = insert_impl(DB_MANAGER.db(), token) {
+        error!("Failed to persist OIDC-issued WebUI token: {}", e);
+        return Ok(redirect_login_error(
+            "Failed to issue session token. See server logs.",
+        ));
+    }
+
+    // Do NOT ship the access token as a URL query parameter — it would leak
+    // into browser history, Referer headers and server access logs. Instead
+    // stash it in a single-use, short-lived server-side handoff entry and
+    // hand the SPA only the handoff id.
+    let redirect_to = result
+        .redirect_after_login
+        .as_deref()
+        .filter(|s| s.starts_with('/'))
+        .map(|s| s.to_string());
+    let handoff = match OidcHandoffEntity::create(token_str, redirect_to) {
+        Ok(h) => h,
+        Err(e) => {
+            error!("Failed to create OIDC handoff entry: {}", e);
+            return Ok(redirect_login_error(
+                "Failed to hand off session. See server logs.",
+            ));
+        }
+    };
+
+    let base = SETTINGS.bichon_base_url.trim_end_matches('/');
+    let target = format!(
+        "{}/sso-callback?handoff={}",
+        base,
+        urlencoding::encode(&handoff.id),
+    );
+
+    Ok(Redirect::temporary(target).into_response())
+}
+
+#[derive(Deserialize)]
+pub struct OidcHandoffRequest {
+    pub handoff: String,
+}
+
+#[derive(Serialize)]
+pub struct OidcHandoffResponse {
+    pub access_token: String,
+    pub redirect_to: String,
+}
+
+/// Consume a one-shot OIDC handoff id and return the freshly minted WebUI
+/// access token in the JSON body. Deletes the handoff entry on success and on
+/// expiry so it can never be replayed.
+#[handler]
+pub async fn oidc_handoff(Json(payload): Json<OidcHandoffRequest>) -> Result<Response> {
+    if !SETTINGS.bichon_oidc_enabled {
+        return Ok(Response::builder()
+            .status(http::StatusCode::NOT_FOUND)
+            .body("OIDC single sign-on is not enabled on this server"));
+    }
+
+    if payload.handoff.is_empty() {
+        return Ok(Response::builder()
+            .status(http::StatusCode::BAD_REQUEST)
+            .body("Missing handoff id"));
+    }
+
+    match OidcHandoffEntity::consume(&payload.handoff) {
+        Ok(Some(entry)) => {
+            let body = OidcHandoffResponse {
+                access_token: entry.access_token,
+                redirect_to: entry.redirect_after_login.unwrap_or_else(|| "/".to_string()),
+            };
+            match serde_json::to_string(&body) {
+                Ok(json) => Ok(Response::builder()
+                    .status(http::StatusCode::OK)
+                    .content_type("application/json")
+                    .header("Cache-Control", "no-store")
+                    .header("Pragma", "no-cache")
+                    .body(json)),
+                Err(e) => {
+                    error!("Failed to serialize handoff response: {}", e);
+                    Ok(Response::builder()
+                        .status(http::StatusCode::INTERNAL_SERVER_ERROR)
+                        .body("Internal error"))
+                }
+            }
+        }
+        Ok(None) => Ok(Response::builder()
+            .status(http::StatusCode::UNAUTHORIZED)
+            .body("SSO handoff not found, expired, or already used")),
+        Err(e) => {
+            error!("Failed to consume OIDC handoff: {}", e);
+            Ok(Response::builder()
+                .status(http::StatusCode::INTERNAL_SERVER_ERROR)
+                .body("Failed to consume handoff"))
+        }
+    }
+}
+
+fn sanitize_redirect(input: Option<String>) -> Option<String> {
+    input.and_then(|s| {
+        if s.starts_with('/') && !s.starts_with("//") {
+            Some(s)
+        } else {
+            None
+        }
+    })
+}
+
+fn redirect_login_error(message: &str) -> Response {
+    let base = SETTINGS.bichon_base_url.trim_end_matches('/');
+    let target = format!(
+        "{}/sign-in?sso_error={}",
+        base,
+        urlencoding::encode(message)
+    );
+    Redirect::temporary(target).into_response()
+}

--- a/env/bichon.env
+++ b/env/bichon.env
@@ -42,3 +42,29 @@ BICHON_ENABLE_REST_HTTPS=false
 
 # Enable HTTP response compression (gzip or brotli)
 BICHON_HTTP_COMPRESSION_ENABLED=true
+
+# --- OpenID Connect (OIDC) single sign-on ------------------------------------
+# Enable OIDC login. When true, all four of the settings below must be set.
+BICHON_OIDC_ENABLED=false
+
+# Issuer URL of the OIDC provider (without the /.well-known/openid-configuration
+# suffix). Example: https://auth.example.com/application/o/bichon/
+BICHON_OIDC_ISSUER_URL=
+
+# OAuth2 client ID registered with the IdP
+BICHON_OIDC_CLIENT_ID=
+
+# OAuth2 client secret registered with the IdP
+BICHON_OIDC_CLIENT_SECRET=
+
+# Redirect URI registered with the IdP. Must resolve to Bichon's
+# /api/auth/oidc/callback endpoint. Example: http://localhost:15630/api/auth/oidc/callback
+BICHON_OIDC_REDIRECT_URI=
+
+# Global role ID assigned to auto-provisioned OIDC users.
+# Defaults to the built-in Member role (100200000000000).
+BICHON_OIDC_DEFAULT_ROLE_ID=100200000000000
+
+# When true and OIDC is configured, /sign-in immediately redirects to the IdP.
+# Users can still reach the local login form via /sign-in?local=1
+BICHON_OIDC_AUTO_REDIRECT=false

--- a/web/src/features/auth/user-auth-form.tsx
+++ b/web/src/features/auth/user-auth-form.tsx
@@ -17,7 +17,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import { HTMLAttributes, useState } from 'react'
+import { HTMLAttributes, useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { cn, toSearchParams } from '@/lib/utils'
@@ -48,15 +48,45 @@ import { useEdition } from '@/hooks/use-edition'
 
 type UserAuthFormProps = HTMLAttributes<HTMLDivElement>
 
+function buildOidcLoginUrl(redirectTo: string): string {
+  const injectedBase = (window as unknown as { __BICHON_BASE__?: string }).__BICHON_BASE__
+  const base = !injectedBase || injectedBase === '/' ? '' : injectedBase.replace(/\/$/, '')
+  const params = new URLSearchParams()
+  if (redirectTo && redirectTo !== '/') {
+    params.set('redirect_to', redirectTo)
+  }
+  const qs = params.toString()
+  return `${base}/api/auth/oidc/login${qs ? `?${qs}` : ''}`
+}
+
 export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
   const [isLoading, setIsLoading] = useState(false)
   const { setTheme } = useTheme();
   const navigate = useNavigate()
   const { t } = useTranslation()
-  const { isPro } = useEdition()
+  const { oidcEnabled, oidcAutoRedirect } = useEdition()
 
   const { search } = useLocation();
-  const redirect = toSearchParams(search).get('redirect') || '/';
+  const searchParams = toSearchParams(search);
+  const redirect = searchParams.get('redirect') || '/';
+  const localOnly = searchParams.get('local') === '1';
+  const ssoError = searchParams.get('sso_error');
+
+  useEffect(() => {
+    if (ssoError) {
+      toast({
+        variant: 'destructive',
+        title: t('auth.loginFailed'),
+        description: ssoError,
+      })
+    }
+  }, [ssoError, t])
+
+  useEffect(() => {
+    if (oidcEnabled && oidcAutoRedirect && !localOnly && !ssoError) {
+      window.location.href = buildOidcLoginUrl(redirect)
+    }
+  }, [oidcEnabled, oidcAutoRedirect, localOnly, ssoError, redirect])
 
   const formSchema = getFormSchema(t)
   const form = useForm<LoginFormValues>({
@@ -159,13 +189,13 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
               {t('auth.login')}
             </Button>
 
-            {isPro && (
+            {oidcEnabled && (
               <Button
                 variant='outline'
                 className='mt-2'
                 type='button'
                 onClick={() => {
-                  window.location.href = '/api/auth/oidc/login'
+                  window.location.href = buildOidcLoginUrl(redirect)
                 }}
               >
                 <Shield size={16} className='mr-2' />

--- a/web/src/hooks/use-edition.ts
+++ b/web/src/hooks/use-edition.ts
@@ -5,6 +5,8 @@ export interface EditionInfo {
   features: string[]
   edition: 'community' | 'pro' | 'enterprise'
   version: string
+  oidc_enabled?: boolean
+  oidc_auto_redirect?: boolean
 }
 
 async function fetchEdition(): Promise<EditionInfo> {
@@ -24,5 +26,7 @@ export function useEdition() {
     isPro: data?.edition === 'pro' || data?.edition === 'enterprise',
     edition: data?.edition ?? 'community',
     features: data?.features ?? [],
+    oidcEnabled: data?.oidc_enabled ?? false,
+    oidcAutoRedirect: data?.oidc_auto_redirect ?? false,
   } as const
 }

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { Route as rootRoute } from './routes/__root'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated/route'
 import { Route as AuthenticatedIndexImport } from './routes/_authenticated/index'
+import { Route as authSsoCallbackImport } from './routes/(auth)/sso-callback'
 import { Route as authSignInImport } from './routes/(auth)/sign-in'
 import { Route as auth500Import } from './routes/(auth)/500'
 import { Route as AuthenticatedSearchIndexImport } from './routes/_authenticated/search/index'
@@ -153,6 +154,12 @@ const AuthenticatedSettingsRouteLazyRoute =
   } as any).lazy(() =>
     import('./routes/_authenticated/settings/route.lazy').then((d) => d.Route),
   )
+
+const authSsoCallbackRoute = authSsoCallbackImport.update({
+  id: '/(auth)/sso-callback',
+  path: '/sso-callback',
+  getParentRoute: () => rootRoute,
+} as any)
 
 const authSignInRoute = authSignInImport.update({
   id: '/(auth)/sign-in',
@@ -366,6 +373,13 @@ declare module '@tanstack/react-router' {
       path: '/sign-in'
       fullPath: '/sign-in'
       preLoaderRoute: typeof authSignInImport
+      parentRoute: typeof rootRoute
+    }
+    '/(auth)/sso-callback': {
+      id: '/(auth)/sso-callback'
+      path: '/sso-callback'
+      fullPath: '/sso-callback'
+      preLoaderRoute: typeof authSsoCallbackImport
       parentRoute: typeof rootRoute
     }
     '/_authenticated/settings': {
@@ -651,6 +665,7 @@ export interface FileRoutesByFullPath {
   '': typeof AuthenticatedRouteRouteWithChildren
   '/500': typeof errors500LazyRoute
   '/sign-in': typeof authSignInRoute
+  '/sso-callback': typeof authSsoCallbackRoute
   '/settings': typeof AuthenticatedSettingsRouteLazyRouteWithChildren
   '/users': typeof AuthenticatedUsersRouteLazyRouteWithChildren
   '/401': typeof errors401LazyRoute
@@ -682,6 +697,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/500': typeof errors500LazyRoute
   '/sign-in': typeof authSignInRoute
+  '/sso-callback': typeof authSsoCallbackRoute
   '/401': typeof errors401LazyRoute
   '/403': typeof errors403LazyRoute
   '/404': typeof errors404LazyRoute
@@ -713,6 +729,7 @@ export interface FileRoutesById {
   '/_authenticated': typeof AuthenticatedRouteRouteWithChildren
   '/(auth)/500': typeof auth500Route
   '/(auth)/sign-in': typeof authSignInRoute
+  '/(auth)/sso-callback': typeof authSsoCallbackRoute
   '/_authenticated/settings': typeof AuthenticatedSettingsRouteLazyRouteWithChildren
   '/_authenticated/users': typeof AuthenticatedUsersRouteLazyRouteWithChildren
   '/(errors)/401': typeof errors401LazyRoute
@@ -748,6 +765,7 @@ export interface FileRouteTypes {
     | ''
     | '/500'
     | '/sign-in'
+    | '/sso-callback'
     | '/settings'
     | '/users'
     | '/401'
@@ -778,6 +796,7 @@ export interface FileRouteTypes {
   to:
     | '/500'
     | '/sign-in'
+    | '/sso-callback'
     | '/401'
     | '/403'
     | '/404'
@@ -807,6 +826,7 @@ export interface FileRouteTypes {
     | '/_authenticated'
     | '/(auth)/500'
     | '/(auth)/sign-in'
+    | '/(auth)/sso-callback'
     | '/_authenticated/settings'
     | '/_authenticated/users'
     | '/(errors)/401'
@@ -841,6 +861,7 @@ export interface RootRouteChildren {
   AuthenticatedRouteRoute: typeof AuthenticatedRouteRouteWithChildren
   auth500Route: typeof auth500Route
   authSignInRoute: typeof authSignInRoute
+  authSsoCallbackRoute: typeof authSsoCallbackRoute
   errors401LazyRoute: typeof errors401LazyRoute
   errors403LazyRoute: typeof errors403LazyRoute
   errors404LazyRoute: typeof errors404LazyRoute
@@ -852,6 +873,7 @@ const rootRouteChildren: RootRouteChildren = {
   AuthenticatedRouteRoute: AuthenticatedRouteRouteWithChildren,
   auth500Route: auth500Route,
   authSignInRoute: authSignInRoute,
+  authSsoCallbackRoute: authSsoCallbackRoute,
   errors401LazyRoute: errors401LazyRoute,
   errors403LazyRoute: errors403LazyRoute,
   errors404LazyRoute: errors404LazyRoute,
@@ -872,6 +894,7 @@ export const routeTree = rootRoute
         "/_authenticated",
         "/(auth)/500",
         "/(auth)/sign-in",
+        "/(auth)/sso-callback",
         "/(errors)/401",
         "/(errors)/403",
         "/(errors)/404",
@@ -901,6 +924,9 @@ export const routeTree = rootRoute
     },
     "/(auth)/sign-in": {
       "filePath": "(auth)/sign-in.tsx"
+    },
+    "/(auth)/sso-callback": {
+      "filePath": "(auth)/sso-callback.tsx"
     },
     "/_authenticated/settings": {
       "filePath": "_authenticated/settings/route.lazy.tsx",

--- a/web/src/routes/(auth)/sso-callback.tsx
+++ b/web/src/routes/(auth)/sso-callback.tsx
@@ -1,0 +1,101 @@
+//
+// Copyright (c) 2025-2026 rustmailer.com (https://rustmailer.com)
+//
+// This file is part of the Bichon Email Archiving Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { useEffect } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { setToken } from '@/stores/authStore'
+import axiosInstance from '@/api/axiosInstance'
+import { Loader2 } from 'lucide-react'
+
+interface HandoffResponse {
+  access_token: string
+  redirect_to: string
+}
+
+function SsoCallback() {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const handoffId = params.get('handoff')
+
+    // Remove the handoff id from the browser URL immediately so it does not
+    // linger in history, referer headers or window.location.
+    window.history.replaceState({}, '', window.location.pathname)
+
+    if (!handoffId) {
+      navigate({
+        to: '/sign-in',
+        search: { sso_error: 'Missing SSO handoff id' } as any,
+      })
+      return
+    }
+
+    let cancelled = false
+    axiosInstance
+      .post<HandoffResponse>('api/auth/oidc/handoff', { handoff: handoffId })
+      .then((res) => {
+        if (cancelled) return
+        const { access_token, redirect_to } = res.data
+        if (!access_token) {
+          navigate({
+            to: '/sign-in',
+            search: { sso_error: 'Empty handoff response from server' } as any,
+          })
+          return
+        }
+        setToken({
+          success: true,
+          access_token,
+          theme: null,
+          language: null,
+          error_message: null,
+        } as any)
+        const target = redirect_to && redirect_to.startsWith('/') ? redirect_to : '/'
+        navigate({ to: target })
+      })
+      .catch((err) => {
+        if (cancelled) return
+        const msg =
+          err?.response?.data && typeof err.response.data === 'string'
+            ? err.response.data
+            : 'Failed to complete SSO login'
+        navigate({
+          to: '/sign-in',
+          search: { sso_error: msg } as any,
+        })
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [navigate])
+
+  return (
+    <div className='flex min-h-screen items-center justify-center'>
+      <div className='flex flex-col items-center gap-2'>
+        <Loader2 className='h-8 w-8 animate-spin' />
+        <p className='text-sm text-muted-foreground'>Signing you in…</p>
+      </div>
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/(auth)/sso-callback')({
+  component: SsoCallback,
+})


### PR DESCRIPTION
# OpenID Connect single sign-on for the Bichon WebUI

## Summary

Bichon can now delegate WebUI authentication to any OpenID Connect
provider (Authentik, Keycloak, PocketID, Authelia, Zitadel, Dex, …).
Users sign in through their existing IdP, and Bichon issues its normal
short-lived WebUI access token on success. Local username/password
login stays fully functional; OIDC is strictly additive and opt-in via
`BICHON_OIDC_ENABLED`.

The change is scoped to the *login path* only. RBAC, per-account ACLs,
API tokens and the admin bootstrap user are all unchanged.

## Motivation

The current WebUI login is username + password with reversibly
encrypted passwords stored in memdb. In a self-hosted, multi-user
setup this means:

- every user needs an in-Bichon password separate from their normal
  SSO identity,
- password resets and off-boarding happen inside Bichon instead of
  centrally in the IdP,
- MFA has to be re-implemented in Bichon to have any effect on
  WebUI access.

Issue #36 asks for OIDC support so authentication (including MFA,
password policy, session revocation) can be delegated to the
organisation's identity provider. This PR implements exactly that
delegation — without pulling in a full identity-management stack.

## What's implemented

### End-to-end flow

1. User clicks *Sign in with SSO* (or is redirected automatically
   when `BICHON_OIDC_AUTO_REDIRECT=true`).
2. `GET /api/auth/oidc/login` builds an Authorization Code + PKCE
   request with random CSRF state and a 256-bit nonce, persists the
   pending state in memdb, and 307-redirects to the IdP.
3. The IdP redirects back to `GET /api/auth/oidc/callback?code=…&state=…`.
4. Bichon exchanges the code, verifies the ID token, resolves or
   auto-provisions the Bichon user, mints a fresh WebUI access token,
   and stores it in a single-use handoff entry (60 s TTL).
5. Browser is 307-redirected to `/sso-callback?handoff=<id>`.
6. The SPA POSTs the handoff id to `/api/auth/oidc/handoff` and
   receives the access token in the JSON response body. The token is
   stored in the existing `authStore` (localStorage) — the exact same
   session mechanism as password login.

### Configuration

All configuration is via environment variables / CLI flags, consistent
with the rest of Bichon:

| Variable | Purpose |
|---|---|
| `BICHON_OIDC_ENABLED` | Master switch (default `false`) |
| `BICHON_OIDC_ISSUER_URL` | IdP issuer; `.well-known/openid-configuration` is appended for discovery |
| `BICHON_OIDC_CLIENT_ID` / `BICHON_OIDC_CLIENT_SECRET` | OAuth2 client credentials |
| `BICHON_OIDC_REDIRECT_URI` | Must match what is registered with the IdP |
| `BICHON_OIDC_DEFAULT_ROLE_ID` | Global role assigned to auto-provisioned users (defaults to the built-in Member role) |
| `BICHON_OIDC_AUTO_REDIRECT` | `/sign-in` redirects to IdP immediately; local form stays reachable via `/sign-in?local=1` |

`/api/v1/features` exposes `oidc_enabled` and `oidc_auto_redirect` so
the SPA can adjust its UI without a separate probe.

### User resolution

Each successful callback resolves a Bichon user in this order:

1. `(sso_provider, sso_id)` — same subject that has logged in before.
2. `email` — an existing user (e.g. the built-in admin, or a
   password-created user) with a matching email address; the SSO
   identity is bound to that user for subsequent logins.
3. Auto-provision a new user with `BICHON_OIDC_DEFAULT_ROLE_ID` as
   the single global role. Username is derived from
   `preferred_username`/`name`/`email` local-part with a numeric
   suffix on collision. No password is set on the new user.

The `sso_id` / `sso_provider` fields already existed on
`BichonUserV2` (scaffolding for #36); this PR gives them behaviour.

### Security model

The implementation follows RFC 6749 (OAuth 2.0), RFC 7636 (PKCE),
OpenID Connect Core 1.0 §3.1 (Authorization Code Flow) and the
current OAuth 2.0 Security Best Current Practice guidance.

**Preventing token leakage.** The freshly minted WebUI access token
is never placed in a URL query parameter. It is stashed server-side
under a single-use handoff id (256 bits of CSPRNG entropy, 60 s TTL,
atomic delete-on-read) and the SPA fetches it via
`POST /api/auth/oidc/handoff`. The response carries
`Cache-Control: no-store` and `Pragma: no-cache`. The handoff id
itself is stripped from `window.location` via `history.replaceState`
before the fetch, so it never enters browser history or `Referer`
headers.

**ID token verification.** Only `HS256` is accepted, verified with
HMAC-SHA256 (via `ring`) against the client secret. Other algorithms
are rejected outright — silently trusting an unverified signature
would allow token forgery if the IdP or the transport were ever
compromised. RS256/ES256 via JWKS is intentionally deferred to a
follow-up (see *Known limitations*). All standard claims are checked:
`iss` (issuer), `aud` (client_id), `exp` with 60 s clock skew, and
`nonce` — the last with a constant-time byte compare to defeat
timing side channels.

**CSRF and replay.** The Authorization Code Flow's opaque `state`
parameter is generated by the `oauth2` crate, persisted in memdb,
and verified on callback. PKCE (S256) prevents authorization-code
interception. The nonce binds the ID token to this specific login
attempt.

**Attack-surface hygiene.** IdP-controlled error text is never
surfaced in the browser response; details go to server logs only.
Token-exchange errors are formatted with `Display`, not `Debug`, so
oauth2-crate diagnostics do not accidentally echo request headers
(which include the client secret when `client_secret_basic` is used).
The `redirect_to` query parameter is sanitised to relative paths
(`/`-prefixed, `//` blocked) to prevent open-redirect abuse.

**State hygiene.** A new periodic task (`oidc-cleanup`) runs every
15 minutes and drops expired pending states (>10 min old) and
handoff entries (>60 s old).

### Frontend

- `useEdition()` reads the new `oidc_enabled` / `oidc_auto_redirect`
  flags from `/api/v1/features` and exposes them to the app.
- `UserAuthForm` shows the *Sign in with SSO* button whenever the
  server has OIDC enabled (the previous `isPro` gating was Bichon's
  original Pro/Enterprise stub; that gating is now driven by server
  configuration instead of edition).
- When `BICHON_OIDC_AUTO_REDIRECT` is on, the sign-in page redirects
  to the IdP immediately. `?local=1` and returning `?sso_error=…`
  both suppress the auto-redirect so users always have a way back to
  the local login form (important for the built-in `admin` account
  before any SSO user exists).
- New `/sso-callback` route handles the token handoff. Errors from
  the callback are shown as toast notifications on the sign-in page.

## Files touched

- `crates/core/src/oidc/` — new module: `discovery`, `flow`,
  `id_token`, `pending`, `handoff`, `task`.
- `crates/core/src/settings/cli.rs` — `BICHON_OIDC_DEFAULT_ROLE_ID`,
  `BICHON_OIDC_AUTO_REDIRECT` (the four existing `BICHON_OIDC_*`
  fields were already scaffolded).
- `crates/core/src/users/mod.rs` — `find_or_provision_sso_user()`
  plus username-derivation and collision-resolution helpers.
- `crates/core/src/tasks/mod.rs` — registers `OidcCleanTask`.
- `crates/server/src/rest/public/oidc.rs` — three new handlers.
- `crates/server/src/rest/public/features.rs` — advertises the two
  new server-side flags.
- `crates/server/src/rest/mod.rs` — route wiring for
  `/api/auth/oidc/{login,callback,handoff}`.
- `web/src/hooks/use-edition.ts` — reads new flags.
- `web/src/features/auth/user-auth-form.tsx` — SSO button, auto-
  redirect, `?local=1` handling, `?sso_error=…` toast.
- `web/src/routes/(auth)/sso-callback.tsx` — new handoff route.
- `env/bichon.env`, `README.md` — documentation.

## Backwards compatibility

- OIDC is off by default; existing deployments are unaffected.
- The `/api/login` password endpoint, `AccessTokenModel`,
  `ApiGuard`, and the admin bootstrap are untouched.
- The two previously-existing `sso_id` / `sso_provider` fields on
  `BichonUserV2` are now populated on OIDC logins; existing users
  continue to work with `password` only.
- The `/api/v1/features` response gains two optional fields
  (`oidc_enabled`, `oidc_auto_redirect`). Older WebUI builds ignore
  them.

## Known limitations (deliberately deferred)

- **Only HS256.** JWKS-based RS256/ES256 verification is not yet
  implemented. Providers configured for asymmetric signing will be
  rejected with a clear error message pointing at the algorithm.
  Follow-up ticket recommended.
- **`email_verified` not enforced.** Auto-provisioning trusts the
  IdP's `email` claim. If your IdP allows unverified email addresses,
  restrict Bichon access via the IdP's application ACL rather than
  relying on this claim.
- **No login-CSRF cookie** on `/api/auth/oidc/login`. In the current
  threat model (self-hosted deployment, IdP with its own MFA and
  session controls) an attacker can at worst force a victim's browser
  to *start* an OIDC login flow. They cannot complete it against the
  victim's IdP session without controlling the callback. Adding a
  double-submit cookie is straightforward if this becomes relevant.
- **No IdP-initiated single logout.** Signing out of Bichon only
  invalidates the local WebUI token. RP-initiated logout against the
  IdP's `end_session_endpoint` is not wired up yet.

## Testing performed

End-to-end against a live Authentik instance:

- Fresh install, no local users besides the built-in admin.
  → *Sign in with SSO* provisions a new user, assigns the Member
  role, issues a WebUI token, lands on the dashboard.
- Second login with the same account. → same user, no duplicate,
  `sso_id`/`sso_provider` reused.
- `BICHON_OIDC_AUTO_REDIRECT=true`. → `/sign-in` redirects to
  Authentik on load; `/sign-in?local=1` shows the password form.
- Handoff URL inspected: contains only the opaque handoff id;
  browser history and `document.location.search` are cleared before
  the fetch; the returned JSON carries `Cache-Control: no-store`.
- Handoff replay: second POST with the same handoff id returns
  `401 Unauthorized`.
- Invalid `state` on callback: rejected with `redirect_login_error`.
- Malicious `redirect_to=//evil.example.com`: rejected by the
  sanitiser; user lands on `/`.

`cargo check --workspace` passes on the resulting tree; the frontend
builds without new type errors (one pre-existing TS error in
`account-settings-page.tsx:58` remains, unrelated to this PR).

## Commits

Five focused commits, easy to review in order:

1. `chore: ignore local scratch and playwright output`
2. `feat(core): add OIDC single sign-on client`
3. `feat(server): expose OIDC login, callback and handoff endpoints`
4. `feat(web): add OIDC sign-in flow and secure token handoff`
5. `docs: document OIDC single sign-on setup`
