### PR TITLE
fix(imap): confirm retired-UID tail via message count before flagging

### DIFF
--- a/crates/core/src/imap/executor.rs
+++ b/crates/core/src/imap/executor.rs
@@ -23,6 +23,7 @@ use crate::envelope::extractor::extract_envelope_and_store_it;
 use crate::error::code::ErrorCode;
 use crate::imap::session::SessionStream;
 use crate::raise_error;
+use crate::store::tantivy::envelope::ENVELOPE_MANAGER;
 use crate::{error::BichonResult, imap::manager::ImapConnectionManager};
 use async_imap::types::Name;
 use async_imap::Session;
@@ -226,24 +227,8 @@ impl ImapExecutor {
                     start_uid,
                     examined.uid_next,
                 ) {
-                    tracing::warn!(
-                        account_id = account.id,
-                        mailbox = %mailbox.name,
-                        start_uid,
-                        uid_next = examined.uid_next,
-                        "{}",
-                        msg
-                    );
-                    DownloadState::append_session_error(account.id, msg)?;
-                    DownloadState::update_folder_progress(
-                        account.id,
-                        mailbox.name.clone(),
-                        0,
-                        0,
-                        FolderStatus::Failed,
-                        Some("UID enumeration came back empty despite new mail on server. Retrying on next sync.".into()),
-                    )?;
-                    return Ok(None);
+                    return resolve_empty_enumeration(account, mailbox, &examined, start_uid, msg)
+                        .await;
                 }
             }
             DownloadState::update_folder_progress(
@@ -499,24 +484,8 @@ impl ImapExecutor {
                     start_uid,
                     examined.uid_next,
                 ) {
-                    tracing::warn!(
-                        account_id = account.id,
-                        mailbox = %mailbox.name,
-                        start_uid,
-                        uid_next = examined.uid_next,
-                        "{}",
-                        msg
-                    );
-                    DownloadState::append_session_error(account.id, msg)?;
-                    DownloadState::update_folder_progress(
-                        account.id,
-                        mailbox.name.clone(),
-                        0,
-                        0,
-                        FolderStatus::Failed,
-                        Some("UID enumeration came back empty despite new mail on server. Retrying on next sync.".into()),
-                    )?;
-                    return Ok(None);
+                    return resolve_empty_enumeration(account, mailbox, &examined, start_uid, msg)
+                        .await;
                 }
             }
             DownloadState::update_folder_progress(
@@ -1170,6 +1139,83 @@ fn empty_enumeration_anomaly(
     } else {
         None
     }
+}
+
+/// Resolve an empty incremental enumeration once `empty_enumeration_anomaly`
+/// has flagged it as suspicious.
+///
+/// The pure guard only knows `UIDNEXT > start_uid`, which cannot distinguish a
+/// truncated/throttled empty (real mail we must NOT skip) from a retired-UID
+/// tail (Gmail relabel/archive/move leaves `UIDNEXT` above the last surviving
+/// message, so `{start}:*` is legitimately empty). Confirm with an
+/// authoritative message count: `EXISTS` from EXAMINE and the local stored
+/// count are both immune to the SEARCH/FETCH truncation that fools the guard.
+///
+/// Returns the value the caller should return from its fetch fn:
+/// - `Ok(Some(uid))` — retired tail confirmed; advance `highest_uid` to `uid`.
+/// - `Ok(None)` — genuine gap; refuse to advance and retry next sync.
+async fn resolve_empty_enumeration(
+    account: &AccountModel,
+    mailbox: &MailBox,
+    examined: &async_imap::types::Mailbox,
+    start_uid: u64,
+    anomaly_msg: String,
+) -> BichonResult<Option<u32>> {
+    let server_count = examined.exists as u64;
+    let local_count = ENVELOPE_MANAGER.count_for_mailbox(account.id, mailbox.id)? as u64;
+
+    if server_count <= local_count {
+        // Retired-UID tail: the folder holds no more mail than we already
+        // store, so the empty range is genuinely empty. Advance past it so the
+        // guard stops re-firing every sync. Safe: we cannot skip mail that is
+        // not there. (Conservative on the oversized-skipped edge: if the folder
+        // has messages skipped for size, server_count may exceed local_count
+        // and we simply fall through to the retry path -- never skipping mail.)
+        let new_highest = examined
+            .uid_next
+            .unwrap_or(0)
+            .saturating_sub(1)
+            .max(start_uid as u32);
+        info!(
+            account_id = account.id,
+            mailbox = %mailbox.name,
+            server_count,
+            local_count,
+            new_highest,
+            "Empty range confirmed as retired-UID tail (server count <= local); advancing highest_uid past it."
+        );
+        DownloadState::update_folder_progress(
+            account.id,
+            mailbox.name.clone(),
+            0,
+            0,
+            FolderStatus::Success,
+            Some("No new emails (retired-UID tail).".into()),
+        )?;
+        return Ok(Some(new_highest));
+    }
+
+    // Server genuinely holds more mail than we do -> real gap -> refuse & retry.
+    tracing::warn!(
+        account_id = account.id,
+        mailbox = %mailbox.name,
+        start_uid,
+        uid_next = examined.uid_next,
+        server_count,
+        local_count,
+        "{}",
+        anomaly_msg
+    );
+    DownloadState::append_session_error(account.id, anomaly_msg)?;
+    DownloadState::update_folder_progress(
+        account.id,
+        mailbox.name.clone(),
+        0,
+        0,
+        FolderStatus::Failed,
+        Some("UID enumeration came back empty despite new mail on server. Retrying on next sync.".into()),
+    )?;
+    Ok(None)
 }
 
 fn parse_message_id_header(header_bytes: &[u8]) -> Option<String> {

--- a/crates/core/src/store/tantivy/envelope.rs
+++ b/crates/core/src/store/tantivy/envelope.rs
@@ -867,6 +867,18 @@ impl IndexManager {
         }
     }
 
+    /// Cheap count of stored envelopes for a mailbox (no ID materialization,
+    /// unlike `get_message_ids_for_mailbox`). Used to distinguish a retired-UID
+    /// tail from a truncated enumeration when the incremental fetch comes back
+    /// empty.
+    pub fn count_for_mailbox(&self, account_id: u64, mailbox_id: u64) -> BichonResult<usize> {
+        let searcher = self.create_searcher()?;
+        let query = self.mailbox_query(account_id, mailbox_id);
+        searcher
+            .search(&query, &Count)
+            .map_err(|e| raise_error!(format!("{:#?}", e), ErrorCode::InternalError))
+    }
+
     pub fn get_max_uid(&self, account_id: u64, mailbox_id: u64) -> BichonResult<Option<u64>> {
         let searcher = self.create_searcher()?;
 


### PR DESCRIPTION
### Summary

The empty-enumeration guard added in 2.0.1 (#340) produces a persistent false positive on Gmail (and other servers that retire UIDs). When a folder's highest surviving UID sits below UIDNEXT - 1 — which happens routinely on Gmail whenever messages are relabeled, archived, or moved out of a folder — every sync logs a "Refusing to advance highest_uid" warning that never clears, and highest_uid stays pinned below UIDNEXT indefinitely.

`Mailbox 'Work': UID FETCH <start>:* returned no UIDs but server UIDNEXT=<n> (<k> messages in range). Refusing to advance highest_uid to avoid skipping them; the next sync will retry.`

The range is genuinely empty (the UIDs were retired, not withheld), so there is nothing for the retry to recover — the warning recurs forever.

### **Root cause**

empty_enumeration_anomaly (crates/core/src/imap/executor.rs) decides purely on UIDNEXT > start_uid. That assumes a UID gap between highest_uid and UIDNEXT implies undelivered messages. On Gmail this is false: UIDNEXT only ever increases, and relabeling / archiving / moving a message retires its UID in that folder without lowering UIDNEXT. So a folder whose last surviving message is UID 337 can sit at UIDNEXT=344 with 338–343 being retired (empty) slots. UID FETCH 338:* correctly returns nothing, but the guard reads that as "6 messages I'm refusing to skip" and re-flags every sync.

The ({} messages in range) figure is UIDNEXT - start_uid, i.e. a slot count, not a confirmed message count — for a retired tail the real count is 0.

### Reproduction

Gmail account synced folder-by-folder (individual labels).
Remove the label from (or archive/move) the message(s) holding the top UIDs of a folder, so the highest surviving UID is below UIDNEXT - 1.
No new mail arrives in that folder.
Every sync logs the "Refusing to advance highest_uid" warning for that folder; it never clears (only real new mail, which pushes a non-empty {start}:*, would).

### Impact

No data loss — the archive is append-only and complete for these folders; the tail is genuinely empty. But it produces permanent per-folder error spam and pins highest_uid, which is indistinguishable at a glance from a real truncation/loss anomaly. Users cannot tell benign retired tails from a genuine problem.

### Fix

The guard cannot distinguish a truncated/throttled empty (real mail — must not skip) from a retired-UID tail (benign) from UIDNEXT alone. Confirm with a signal immune to SEARCH/FETCH truncation: the message count. The EXAMINE response already carries exists (server count), and the local stored count is equally authoritative.

When the enumeration is empty and the guard would fire:

If examined.exists <= local_stored_count → the folder holds no more mail than we already store → retired tail → advance highest_uid to UIDNEXT - 1.
Else → server genuinely has more than we hold → real gap → keep the current refuse-and-retry behavior.

This preserves the anti-truncation protection while eliminating the false positive. It's conservative on the oversized-skipped edge: if a folder has messages skipped for max_email_size_bytes, exists can exceed the local count and the guard simply falls through to the retry path — never skipping mail.

Changes: adds a cheap IndexManager::count_for_mailbox (Tantivy Count collector, no ID materialization), and a resolve_empty_enumeration helper called from both fetch_new_mail_range and fetch_new_mail_with_before.

