### PR TITLE
fix(core): count deduplicated imports as duplicates, not successes

### DIFF
--- a/crates/core/src/envelope/extractor.rs
+++ b/crates/core/src/envelope/extractor.rs
@@ -46,8 +46,10 @@ use crate::{
     utils::{compute_content_hash, hex_hash, html::extract_text},
 };
 
-/// The outcome of extracting an envelope: either the message was imported,
-/// or it was skipped because its content hash was already archived.
+/// The outcome of extracting an envelope. `Duplicate` means the message was
+/// skipped because its content hash was already archived. `Imported` covers
+/// every other processed message, including mail dropped by archive rules,
+/// which has always counted as a success on the import surfaces.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[must_use]
 pub enum ExtractOutcome {

--- a/crates/core/src/envelope/extractor.rs
+++ b/crates/core/src/envelope/extractor.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2025-2026 rustmailer.com (https://rustmailer.com)
 //
 // This file is part of the Bichon Email Archiving Project
@@ -16,31 +15,36 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::account::migration::AccountModel;
-use crate::cache::imap::mailbox::MailBox;
-use crate::common::AddrVec;
-use crate::envelope::meta::parse_bichon_metadata;
-use crate::envelope::utils::normalize_subject;
-use crate::error::code::ErrorCode;
-use crate::error::BichonResult;
-use crate::imap::executor::ImapExecutor;
-use crate::message::content::AttachmentInfo;
-use crate::store::blob::{DetachedEmail, BLOB_MANAGER};
-use crate::store::tantivy::attachment::ATTACHMENT_MANAGER;
-use crate::store::tantivy::dedup_cache::DEDUP_CACHE;
-use crate::store::tantivy::envelope::ENVELOPE_MANAGER;
-use crate::store::tantivy::model::{AttachmentModel, EnvelopeWithAttachments};
-use crate::utils::html::extract_text;
-use crate::utils::{compute_content_hash, hex_hash};
-use crate::{id, store::envelope::Envelope};
-use crate::{raise_error, utc_now};
 use async_imap::types::Fetch;
 use bytes::Bytes;
 use mail_parser::{Address, HeaderName, Message, MessageParser, MimeHeaders};
-use tantivy::TantivyDocument;
-use tantivy::schema::Facet;
+use tantivy::{schema::Facet, TantivyDocument};
 use tracing::error;
 use uuid::Uuid;
+
+use crate::{
+    account::migration::AccountModel,
+    cache::imap::mailbox::MailBox,
+    common::AddrVec,
+    envelope::{meta::parse_bichon_metadata, utils::normalize_subject},
+    error::{code::ErrorCode, BichonResult},
+    id,
+    imap::executor::ImapExecutor,
+    message::content::AttachmentInfo,
+    raise_error,
+    store::{
+        blob::{DetachedEmail, BLOB_MANAGER},
+        envelope::Envelope,
+        tantivy::{
+            attachment::ATTACHMENT_MANAGER,
+            dedup_cache::DEDUP_CACHE,
+            envelope::ENVELOPE_MANAGER,
+            model::{AttachmentModel, EnvelopeWithAttachments},
+        },
+    },
+    utc_now,
+    utils::{compute_content_hash, hex_hash, html::extract_text},
+};
 
 /// The outcome of extracting an envelope: either the message was imported,
 /// or it was skipped because its content hash was already archived.
@@ -110,11 +114,11 @@ async fn extract_envelope_core(
     account_id: u64,
     mailbox_id: u64,
 ) -> BichonResult<ExtractOutcome> {
-    //The content hash of the original raw EML
+    // The content hash of the original raw EML
     let email_content_hash = compute_content_hash(body);
     if DEDUP_CACHE.contains(account_id, mailbox_id, &email_content_hash) {
         tracing::debug!("Duplicate email detected");
-        //println!("Duplicate email detected");
+        // println!("Duplicate email detected");
         return Ok(ExtractOutcome::Duplicate);
     }
     let message: Message<'_> = MessageParser::new().parse(body).ok_or_else(|| {
@@ -127,7 +131,11 @@ async fn extract_envelope_core(
     if let Ok(account) = AccountModel::get(account_id) {
         if let Some(ref rules) = account.archive_rules {
             let sender = message.from().and_then(|addr| {
-                AddrVec::from(addr).0.into_iter().next().and_then(|a| a.address)
+                AddrVec::from(addr)
+                    .0
+                    .into_iter()
+                    .next()
+                    .and_then(|a| a.address)
             });
             let subject = message.subject().map(|s| s.to_string());
 
@@ -213,11 +221,12 @@ async fn extract_envelope_core(
         .and_then(|add| add.address)
         .unwrap_or_else(|| "unknown".to_string());
     let attachment_count = message.attachment_count();
-    let attachments = detach_and_store_attachments(body, &message, &email_content_hash, account_id, mailbox_id).await;
+    let attachments =
+        detach_and_store_attachments(body, &message, &email_content_hash, account_id, mailbox_id)
+            .await;
 
     let envelope_id = Uuid::new_v4().to_string();
     let now = utc_now!();
-
 
     let mut final_tags = Vec::new();
 
@@ -226,11 +235,7 @@ async fn extract_envelope_core(
             if let Some(tags) = bmd.tags {
                 let validated_tags: Result<Vec<String>, _> = tags
                     .iter()
-                    .map(|tag| {
-                        Facet::from_text(tag)
-                            .map(|_| tag.clone()) 
-                            .map_err(|e| e)
-                    })
+                    .map(|tag| Facet::from_text(tag).map(|_| tag.clone()).map_err(|e| e))
                     .collect();
 
                 match validated_tags {
@@ -238,10 +243,7 @@ async fn extract_envelope_core(
                         final_tags = valid_list;
                     }
                     Err(e) => {
-                        eprintln!(
-                            "Tag validation failed, ignoring all tags: {:#?}",
-                            e
-                        );
+                        eprintln!("Tag validation failed, ignoring all tags: {:#?}", e);
                     }
                 }
             }
@@ -464,7 +466,8 @@ pub async fn detach_and_store_attachments(
 
     let mut stripped_eml = original_body.to_vec();
     let mut attachment_infos = Vec::new();
-    // Step 1: Collect and sort attachment ranges in reverse to maintain offset integrity
+    // Step 1: Collect and sort attachment ranges in reverse to maintain offset
+    // integrity
     let mut ranges: Vec<_> = message
         .attachments()
         .map(|att| {
@@ -584,10 +587,8 @@ pub async fn detach_and_store_attachments(
     // Run text extraction in a single spawn_blocking batch.
     if !text_candidates.is_empty() {
         if let Ok(mut extracted_map) = tokio::task::spawn_blocking(move || {
-            let mut map: std::collections::HashMap<
-                String,
-                (String, Option<u32>, bool),
-            > = std::collections::HashMap::new();
+            let mut map: std::collections::HashMap<String, (String, Option<u32>, bool)> =
+                std::collections::HashMap::new();
             for c in text_candidates {
                 if let Some(r) =
                     crate::ext::text_extractor::extract_text(&c.file_type, &c.ext, &c.bytes)
@@ -624,8 +625,7 @@ pub fn reattach_eml_content(
     envelope_id: String,
 ) -> BichonResult<(Envelope, Bytes)> {
     let e = ENVELOPE_MANAGER
-        .get_envelope_by_id(account_id, &envelope_id)
-        ?
+        .get_envelope_by_id(account_id, &envelope_id)?
         .ok_or_else(|| {
             raise_error!(
                 format!(
@@ -658,7 +658,7 @@ pub fn reattach_eml_content(
         return Err(raise_error!(
             format!(
                 "Consistency check failed: envelope.attachment_count ({}) does not match attachments.len ({})",
-                e.envelope.attachment_count, 
+                e.envelope.attachment_count,
                 actual_count
             ),
             ErrorCode::InternalError
@@ -679,11 +679,7 @@ pub fn reattach_eml_content(
             let absolute_start = search_cursor + pos;
             let absolute_end = absolute_start + pattern_len;
 
-            tasks.push((
-                absolute_start,
-                absolute_end,
-                detail.content_hash.clone(),
-            ));
+            tasks.push((absolute_start, absolute_end, detail.content_hash.clone()));
             search_cursor = absolute_end;
         }
     }
@@ -701,14 +697,15 @@ pub fn reattach_eml_content(
     Ok((e.envelope, Bytes::from(restored_eml)))
 }
 
-/// Returns the raw EML for an indexed message, self-healing a missing content blob.
+/// Returns the raw EML for an indexed message, self-healing a missing content
+/// blob.
 ///
-/// Behaves like [`reattach_eml_content`], but when the message's content blob is
-/// absent from the blob store it fetches that single message on demand from the
-/// IMAP server (`UID FETCH <uid> (BODY.PEEK[])`), persists it for future requests,
-/// and returns it. If the on-demand fetch itself fails, the original "content not
-/// found" error from [`reattach_eml_content`] is surfaced unchanged so the caller
-/// still produces its 404.
+/// Behaves like [`reattach_eml_content`], but when the message's content blob
+/// is absent from the blob store it fetches that single message on demand from
+/// the IMAP server (`UID FETCH <uid> (BODY.PEEK[])`), persists it for future
+/// requests, and returns it. If the on-demand fetch itself fails, the original
+/// "content not found" error from [`reattach_eml_content`] is surfaced
+/// unchanged so the caller still produces its 404.
 pub async fn reattach_eml_content_self_healing(
     account_id: u64,
     envelope_id: String,
@@ -757,14 +754,15 @@ pub async fn reattach_eml_content_self_healing(
 
 /// Fetches one message from IMAP and re-stores its detached blob.
 ///
-/// On success the freshly fetched raw RFC822 body is returned; it is also queued
-/// (in detached form) into the blob store so subsequent requests hit the cache.
-/// Fails if the message cannot be fetched, or if the fetched bytes do not match
-/// the archived `content_hash` (the server-side message no longer matches what
-/// Bichon archived, so it cannot be treated as a recovery of that blob).
+/// On success the freshly fetched raw RFC822 body is returned; it is also
+/// queued (in detached form) into the blob store so subsequent requests hit the
+/// cache. Fails if the message cannot be fetched, or if the fetched bytes do
+/// not match the archived `content_hash` (the server-side message no longer
+/// matches what Bichon archived, so it cannot be treated as a recovery of that
+/// blob).
 async fn recover_message_blob(envelope: &Envelope) -> BichonResult<Bytes> {
-    let mailbox = MailBox::find_mailbox(envelope.account_id, envelope.mailbox_id)?
-        .ok_or_else(|| {
+    let mailbox =
+        MailBox::find_mailbox(envelope.account_id, envelope.mailbox_id)?.ok_or_else(|| {
             raise_error!(
                 format!(
                     "Mailbox not found: account_id={} mailbox_id={}",
@@ -798,13 +796,22 @@ async fn recover_message_blob(envelope: &Envelope) -> BichonResult<Bytes> {
     // Re-create the detached blob (stripped EML + attachments) so the missing
     // blob is repopulated for future requests. The detached EML is queued under
     // `fetched_hash`, which equals `envelope.content_hash`.
-    let message = MessageParser::new().parse(raw_body.as_slice()).ok_or_else(|| {
-        raise_error!(
-            "Failed to parse fetched email content".into(),
-            ErrorCode::InternalError
-        )
-    })?;
-    detach_and_store_attachments(&raw_body, &message, &fetched_hash, envelope.account_id, envelope.mailbox_id).await;
+    let message = MessageParser::new()
+        .parse(raw_body.as_slice())
+        .ok_or_else(|| {
+            raise_error!(
+                "Failed to parse fetched email content".into(),
+                ErrorCode::InternalError
+            )
+        })?;
+    detach_and_store_attachments(
+        &raw_body,
+        &message,
+        &fetched_hash,
+        envelope.account_id,
+        envelope.mailbox_id,
+    )
+    .await;
 
     Ok(Bytes::from(raw_body))
 }
@@ -897,14 +904,9 @@ mod test {
         assert!(truncated.len() < raw.len());
 
         // Must not panic.
-        let infos = super::detach_and_store_attachments(
-            truncated,
-            &message,
-            "test_content_hash",
-            0,
-            0,
-        )
-        .await;
+        let infos =
+            super::detach_and_store_attachments(truncated, &message, "test_content_hash", 0, 0)
+                .await;
 
         // The attachment count must still match so the consistency check
         // in reattach_eml_content doesn't fail later.

--- a/crates/core/src/envelope/extractor.rs
+++ b/crates/core/src/envelope/extractor.rs
@@ -42,6 +42,15 @@ use tantivy::schema::Facet;
 use tracing::error;
 use uuid::Uuid;
 
+/// The outcome of extracting an envelope: either the message was imported,
+/// or it was skipped because its content hash was already archived.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use]
+pub enum ExtractOutcome {
+    Imported,
+    Duplicate,
+}
+
 pub async fn extract_envelope_and_store_it(
     fetch: Fetch,
     account_id: u64,
@@ -64,14 +73,16 @@ pub async fn extract_envelope_and_store_it(
         }
     };
     let size = fetch.size.unwrap_or(body.len() as u32);
-    extract_envelope_core(body, uid, size, internal_date, account_id, mailbox_id).await
+    extract_envelope_core(body, uid, size, internal_date, account_id, mailbox_id)
+        .await
+        .map(|_| ())
 }
 
 pub async fn extract_envelope_from_eml(
     body: &[u8],
     account_id: u64,
     mailbox_id: u64,
-) -> BichonResult<()> {
+) -> BichonResult<ExtractOutcome> {
     extract_envelope_core(body, 0, body.len() as u32, 0, account_id, mailbox_id).await
 }
 
@@ -79,7 +90,7 @@ pub async fn extract_envelope_from_smtp(
     body: &[u8],
     account_id: u64,
     mailbox_id: u64,
-) -> BichonResult<()> {
+) -> BichonResult<ExtractOutcome> {
     extract_envelope_core(
         body,
         0,
@@ -98,13 +109,13 @@ async fn extract_envelope_core(
     internal_date: i64,
     account_id: u64,
     mailbox_id: u64,
-) -> BichonResult<()> {
+) -> BichonResult<ExtractOutcome> {
     //The content hash of the original raw EML
     let email_content_hash = compute_content_hash(body);
     if DEDUP_CACHE.contains(account_id, mailbox_id, &email_content_hash) {
         tracing::debug!("Duplicate email detected");
         //println!("Duplicate email detected");
-        return Ok(());
+        return Ok(ExtractOutcome::Duplicate);
     }
     let message: Message<'_> = MessageParser::new().parse(body).ok_or_else(|| {
         raise_error!(
@@ -136,7 +147,7 @@ async fn extract_envelope_core(
                     subject = subject.as_deref().unwrap_or("?"),
                     "Email filtered out by archive rules"
                 );
-                return Ok(());
+                return Ok(ExtractOutcome::Imported);
             }
         }
     }
@@ -317,7 +328,7 @@ async fn extract_envelope_core(
     for doc in attachment_docs {
         ATTACHMENT_MANAGER.queue(doc).await;
     }
-    Ok(())
+    Ok(ExtractOutcome::Imported)
 }
 
 pub fn extract_envelope_from_nested_message(

--- a/crates/core/src/ext/event_bus.rs
+++ b/crates/core/src/ext/event_bus.rs
@@ -209,6 +209,7 @@ pub enum Event {
         format: String,
         total: u64,
         success: u64,
+        duplicates: u64,
         failed: u64,
     },
     MailboxRemoved {

--- a/crates/core/src/import/mod.rs
+++ b/crates/core/src/import/mod.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2025-2026 rustmailer.com (https://rustmailer.com)
 //
 // This file is part of the Bichon Email Archiving Project
@@ -16,45 +15,40 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
-//use poem_openapi::Object;
+// use poem_openapi::Object;
 pub mod history;
-pub mod reader;
 pub mod pst;
+pub mod reader;
+use std::{collections::HashMap, path::Path, sync::RwLock};
+
 pub use history::ImportHistory;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::HashMap,
-    path::Path,
-    sync::RwLock,
-};
 
 use crate::{
+    account::migration::{AccountModel, AccountType},
     base64_decode_url_safe,
-    {
-        account::migration::{AccountModel, AccountType},
-        cache::imap::mailbox::{Attribute, AttributeEnum, MailBox},
-        envelope::extractor::{extract_envelope_from_eml, ExtractOutcome},
-        error::{BichonResult, code::ErrorCode},
-        settings::dir::DATA_DIR_MANAGER,
-        utils::create_hash,
-    },
+    cache::imap::mailbox::{Attribute, AttributeEnum, MailBox},
+    envelope::extractor::{extract_envelope_from_eml, ExtractOutcome},
+    error::{code::ErrorCode, BichonResult},
     raise_error,
+    settings::dir::DATA_DIR_MANAGER,
+    utils::create_hash,
 };
 
 /// Maximum byte size of an individual email message after splitting (100 MB).
 const MAX_SINGLE_EML_BYTES: usize = 100 * 1024 * 1024;
 
 /// Max file size accepted via the web upload endpoint.
-pub const MAX_WEB_EML_BYTES: usize = 100 * 1024 * 1024;       // 100 MB
-pub const MAX_WEB_MBOX_BYTES: usize = 1024 * 1024 * 1024;     // 1 GB
+pub const MAX_WEB_EML_BYTES: usize = 100 * 1024 * 1024; // 100 MB
+pub const MAX_WEB_MBOX_BYTES: usize = 1024 * 1024 * 1024; // 1 GB
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "web-api", derive(poem_openapi::Object))]
 pub struct BatchEmlRequest {
     pub account_id: u64,
     pub mail_folder: String,
-    /// A list of emails in base64-encoded format. Each element represents one .eml file.
+    /// A list of emails in base64-encoded format. Each element represents one
+    /// .eml file.
     pub emls: Vec<String>,
 }
 
@@ -87,26 +81,31 @@ pub struct ImportEmls;
 impl ImportEmls {
     pub async fn do_import(mut request: BatchEmlRequest) -> BichonResult<BatchEmlResult> {
         let account = AccountModel::check_account_exists(request.account_id)?;
-        
+
         if !account.enabled {
-            return Err(raise_error!("The account is disabled and cannot be used for this operation.".into(), ErrorCode::InvalidParameter));
+            return Err(raise_error!(
+                "The account is disabled and cannot be used for this operation.".into(),
+                ErrorCode::InvalidParameter
+            ));
         }
 
         let mailbox_id = match account.account_type {
             AccountType::IMAP => {
                 let all_mailboxes = MailBox::list_all(account.id)?;
-                let mailbox = all_mailboxes.into_iter().find(|m| m.name == request.mail_folder);
-                
+                let mailbox = all_mailboxes
+                    .into_iter()
+                    .find(|m| m.name == request.mail_folder);
+
                 match mailbox {
                     Some(mailbox) => mailbox.id,
                     None => return Err(raise_error!(
-                        format!("Mail folder '{}' not found for account ID {}. The target folder must exist before importing.", 
-                                request.mail_folder, 
+                        format!("Mail folder '{}' not found for account ID {}. The target folder must exist before importing.",
+                                request.mail_folder,
                                 request.account_id).into(),
                         ErrorCode::ResourceNotFound
                     )),
                 }
-            },
+            }
             AccountType::NoSync => {
                 let mailbox = MailBox {
                     id: create_hash(request.account_id, &request.mail_folder),
@@ -127,7 +126,7 @@ impl ImportEmls {
                 // Upsert the mailbox, creating it if it doesn't exist
                 MailBox::batch_upsert(&[mailbox])?;
                 mailbox_id
-            },
+            }
         };
 
         let account_id = account.id;
@@ -172,10 +171,10 @@ impl ImportEmls {
             match extract_envelope_from_eml(&decoded, account_id, mailbox_id).await {
                 Ok(ExtractOutcome::Imported) => {
                     success_count += 1;
-                },
+                }
                 Ok(ExtractOutcome::Duplicate) => {
                     duplicate_count += 1;
-                },
+                }
                 Err(e) => {
                     let error_msg = format!(
                         "Failed to extract envelope from EML at index {}: {:?}",
@@ -283,8 +282,8 @@ pub fn detect_format(bytes: &[u8], file_name: &str) -> Option<FileFormat> {
             }
         }
     }
-    // EML: starts with a header line or "Return-Path:", "Received:", "From:", "Date:", etc.
-    // Or check extension
+    // EML: starts with a header line or "Return-Path:", "Received:", "From:",
+    // "Date:", etc. Or check extension
     if bytes.starts_with(b"Return-Path:")
         || bytes.starts_with(b"Received:")
         || bytes.starts_with(b"Date:")
@@ -309,11 +308,12 @@ pub fn detect_format(bytes: &[u8], file_name: &str) -> Option<FileFormat> {
 }
 
 /// Check whether `bytes` looks like a text file by inspecting the first chunk.
-/// Returns `true` if it passes, `false` if it appears to be binary (video, executable, etc.).
+/// Returns `true` if it passes, `false` if it appears to be binary (video,
+/// executable, etc.).
 ///
 /// Email files (EML/MBOX) are text-based with printable ASCII, whitespace, and
-/// optional UTF-8. Binary files like video contain null bytes and high ratios of
-/// non-printable control characters.
+/// optional UTF-8. Binary files like video contain null bytes and high ratios
+/// of non-printable control characters.
 pub fn detect_text_file(bytes: &[u8]) -> bool {
     let check_len = bytes.len().min(8192);
     if check_len == 0 {
@@ -360,7 +360,8 @@ pub fn detect_text_file(bytes: &[u8]) -> bool {
             }
             // standalone continuation byte — not printable
         }
-        // Other control characters (0x01-0x1F except whitespace/Esc) are not counted as printable
+        // Other control characters (0x01-0x1F except whitespace/Esc) are not counted as
+        // printable
 
         i += 1;
     }
@@ -380,7 +381,8 @@ fn validate_import_account(account_id: u64) -> BichonResult<AccountModel> {
     }
     if !matches!(account.account_type, AccountType::NoSync) {
         return Err(raise_error!(
-            "Import is only allowed for NoSync accounts. IMAP accounts sync from the server.".into(),
+            "Import is only allowed for NoSync accounts. IMAP accounts sync from the server."
+                .into(),
             ErrorCode::InvalidParameter
         ));
     }
@@ -432,12 +434,13 @@ pub fn resolve_mailbox_by_account_id(account_id: u64, folder: &str) -> BichonRes
     resolve_mailbox(&account, folder)
 }
 
-/// Process an uploaded file (EML or MBOX) and import into the given account/folder.
-/// This runs synchronously and should be spawned on a background thread.
+/// Process an uploaded file (EML or MBOX) and import into the given
+/// account/folder. This runs synchronously and should be spawned on a
+/// background thread.
 ///
-/// For MBOX files, the file is memory-mapped via `memmap2` and messages are yielded
-/// one at a time — the full file is never loaded into RAM. Individual messages
-/// exceeding `MAX_SINGLE_EML_BYTES` (100 MB) are skipped.
+/// For MBOX files, the file is memory-mapped via `memmap2` and messages are
+/// yielded one at a time — the full file is never loaded into RAM. Individual
+/// messages exceeding `MAX_SINGLE_EML_BYTES` (100 MB) are skipped.
 pub fn process_uploaded_file(
     import_id: &str,
     file_path: &Path,
@@ -515,9 +518,15 @@ pub fn process_uploaded_file(
     };
 
     match format {
-        FileFormat::Eml => process_eml_file(import_id, file_path, account_id, mailbox_id, user_id, folder),
-        FileFormat::Mbox => process_mbox_file(import_id, file_path, account_id, mailbox_id, user_id, folder),
-        FileFormat::Pst => process_pst_upload(import_id, file_path, account_id, mailbox_id, user_id, folder),
+        FileFormat::Eml => process_eml_file(
+            import_id, file_path, account_id, mailbox_id, user_id, folder,
+        ),
+        FileFormat::Mbox => process_mbox_file(
+            import_id, file_path, account_id, mailbox_id, user_id, folder,
+        ),
+        FileFormat::Pst => process_pst_upload(
+            import_id, file_path, account_id, mailbox_id, user_id, folder,
+        ),
     }
 }
 
@@ -525,7 +534,10 @@ pub fn process_uploaded_file(
 fn detect_format_from_file(file_path: &Path, file_name: &str) -> BichonResult<FileFormat> {
     use std::io::Read;
     let mut file = std::fs::File::open(file_path).map_err(|e| {
-        raise_error!(format!("Failed to open file: {}", e), ErrorCode::InternalError)
+        raise_error!(
+            format!("Failed to open file: {}", e),
+            ErrorCode::InternalError
+        )
     })?;
     let mut buf = vec![0u8; 8192];
     let n = file.read(&mut buf).unwrap_or(0);
@@ -552,23 +564,33 @@ fn process_eml_file(
     let file_bytes = match std::fs::read(file_path) {
         Ok(b) => b,
         Err(e) => {
-            fail_progress(import_id, "eml", &format!("Failed to read file: {}", e), user_id, account_id, folder);
+            fail_progress(
+                import_id,
+                "eml",
+                &format!("Failed to read file: {}", e),
+                user_id,
+                account_id,
+                folder,
+            );
             let _ = std::fs::remove_file(file_path);
             return;
         }
     };
 
     let total = 1;
-    update_progress(import_id, ImportProgress {
-        import_id: import_id.to_string(),
-        status: ImportStatus::Processing,
-        format: "eml".to_string(),
-        total,
-        success: 0,
-        duplicates: 0,
-        failed: 0,
-        failed_details: vec![],
-    });
+    update_progress(
+        import_id,
+        ImportProgress {
+            import_id: import_id.to_string(),
+            status: ImportStatus::Processing,
+            format: "eml".to_string(),
+            total,
+            success: 0,
+            duplicates: 0,
+            failed: 0,
+            failed_details: vec![],
+        },
+    );
 
     let (success_count, duplicate_count, failed_details) =
         process_single_eml(&file_bytes, 0, account_id, mailbox_id);
@@ -603,25 +625,36 @@ fn process_mbox_file(
     let mbox = match reader::MboxFile::from_file(file_path) {
         Ok(m) => m,
         Err(e) => {
-            fail_progress(import_id, "mbox", &format!("Failed to open MBOX file: {}", e), user_id, account_id, folder);
+            fail_progress(
+                import_id,
+                "mbox",
+                &format!("Failed to open MBOX file: {}", e),
+                user_id,
+                account_id,
+                folder,
+            );
             let _ = std::fs::remove_file(file_path);
             return;
         }
     };
 
-    // First pass: count total messages (MboxReader is lazy, so this is O(n) but cheap)
+    // First pass: count total messages (MboxReader is lazy, so this is O(n) but
+    // cheap)
     let total = mbox.iter().count();
 
-    update_progress(import_id, ImportProgress {
-        import_id: import_id.to_string(),
-        status: ImportStatus::Processing,
-        format: "mbox".to_string(),
-        total,
-        success: 0,
-        duplicates: 0,
-        failed: 0,
-        failed_details: vec![],
-    });
+    update_progress(
+        import_id,
+        ImportProgress {
+            import_id: import_id.to_string(),
+            status: ImportStatus::Processing,
+            format: "mbox".to_string(),
+            total,
+            success: 0,
+            duplicates: 0,
+            failed: 0,
+            failed_details: vec![],
+        },
+    );
 
     let mut success_count = 0usize;
     let mut duplicate_count = 0usize;
@@ -644,7 +677,9 @@ fn process_mbox_file(
             continue;
         }
 
-        match futures::executor::block_on(extract_envelope_from_eml(eml_bytes, account_id, mailbox_id)) {
+        match futures::executor::block_on(extract_envelope_from_eml(
+            eml_bytes, account_id, mailbox_id,
+        )) {
             Ok(ExtractOutcome::Imported) => {
                 success_count += 1;
             }
@@ -661,16 +696,19 @@ fn process_mbox_file(
 
         // Update progress every 100 items
         if index % 100 == 0 || index == total - 1 {
-            update_progress(import_id, ImportProgress {
-                import_id: import_id.to_string(),
-                status: ImportStatus::Processing,
-                format: "mbox".to_string(),
-                total,
-                success: success_count,
-                duplicates: duplicate_count,
-                failed: failed_details.len(),
-                failed_details: failed_details.clone(),
-            });
+            update_progress(
+                import_id,
+                ImportProgress {
+                    import_id: import_id.to_string(),
+                    status: ImportStatus::Processing,
+                    format: "mbox".to_string(),
+                    total,
+                    success: success_count,
+                    duplicates: duplicate_count,
+                    failed: failed_details.len(),
+                    failed_details: failed_details.clone(),
+                },
+            );
         }
     }
 
@@ -692,7 +730,8 @@ fn process_mbox_file(
     update_progress(import_id, final_progress);
 }
 
-/// Process a single EML byte slice and return (success_count, duplicate_count, failed_details).
+/// Process a single EML byte slice and return (success_count, duplicate_count,
+/// failed_details).
 fn process_single_eml(
     eml_bytes: &[u8],
     index: usize,
@@ -701,33 +740,43 @@ fn process_single_eml(
 ) -> (usize, usize, Vec<FailedItemDetail>) {
     if eml_bytes.len() > MAX_SINGLE_EML_BYTES {
         let size_mb = eml_bytes.len() as f64 / 1024.0 / 1024.0;
-        return (0, 0, vec![FailedItemDetail {
-            index,
-            error_message: format!(
-                "Email is {:.1} MB (limit {} MB). Skipping.",
-                size_mb,
-                MAX_SINGLE_EML_BYTES / 1024 / 1024
-            ),
-        }]);
+        return (
+            0,
+            0,
+            vec![FailedItemDetail {
+                index,
+                error_message: format!(
+                    "Email is {:.1} MB (limit {} MB). Skipping.",
+                    size_mb,
+                    MAX_SINGLE_EML_BYTES / 1024 / 1024
+                ),
+            }],
+        );
     }
 
-    match futures::executor::block_on(extract_envelope_from_eml(eml_bytes, account_id, mailbox_id)) {
+    match futures::executor::block_on(extract_envelope_from_eml(eml_bytes, account_id, mailbox_id))
+    {
         Ok(ExtractOutcome::Imported) => (1, 0, vec![]),
         Ok(ExtractOutcome::Duplicate) => (0, 1, vec![]),
-        Err(e) => (0, 0, vec![FailedItemDetail {
-            index,
-            error_message: format!("{:?}", e),
-        }]),
+        Err(e) => (
+            0,
+            0,
+            vec![FailedItemDetail {
+                index,
+                error_message: format!("{:?}", e),
+            }],
+        ),
     }
 }
 
 /// Process a PST file uploaded via the web UI.
-/// Two-pass approach: count messages first, then process with periodic progress updates.
+/// Two-pass approach: count messages first, then process with periodic progress
+/// updates.
 fn process_pst_upload(
     import_id: &str,
     file_path: &Path,
     account_id: u64,
-    _mailbox_id: u64,  // ignored; PST creates its own mailboxes per folder
+    _mailbox_id: u64, // ignored; PST creates its own mailboxes per folder
     user_id: u64,
     folder: &str,
 ) {
@@ -735,22 +784,32 @@ fn process_pst_upload(
     let total = match pst::count_pst_messages(file_path) {
         Ok(n) => n,
         Err(e) => {
-            fail_progress(import_id, "pst", &format!("{:?}", e), user_id, account_id, folder);
+            fail_progress(
+                import_id,
+                "pst",
+                &format!("{:?}", e),
+                user_id,
+                account_id,
+                folder,
+            );
             let _ = std::fs::remove_file(file_path);
             return;
         }
     };
 
-    update_progress(import_id, ImportProgress {
-        import_id: import_id.to_string(),
-        status: ImportStatus::Processing,
-        format: "pst".to_string(),
-        total,
-        success: 0,
-        duplicates: 0,
-        failed: 0,
-        failed_details: vec![],
-    });
+    update_progress(
+        import_id,
+        ImportProgress {
+            import_id: import_id.to_string(),
+            status: ImportStatus::Processing,
+            format: "pst".to_string(),
+            total,
+            success: 0,
+            duplicates: 0,
+            failed: 0,
+            failed_details: vec![],
+        },
+    );
 
     // Pass 2: process messages with progress updates
     let mut success_count: usize = 0;
@@ -761,7 +820,14 @@ fn process_pst_upload(
     let pst_store = match outlook_pst::open_store(file_path) {
         Ok(s) => s,
         Err(e) => {
-            fail_progress(import_id, "pst", &format!("{:?}", e), user_id, account_id, folder);
+            fail_progress(
+                import_id,
+                "pst",
+                &format!("{:?}", e),
+                user_id,
+                account_id,
+                folder,
+            );
             let _ = std::fs::remove_file(file_path);
             return;
         }
@@ -770,7 +836,14 @@ fn process_pst_upload(
     let ipm_sub_tree = match pst_store.properties().ipm_sub_tree_entry_id() {
         Ok(id) => id,
         Err(e) => {
-            fail_progress(import_id, "pst", &format!("{:?}", e), user_id, account_id, folder);
+            fail_progress(
+                import_id,
+                "pst",
+                &format!("{:?}", e),
+                user_id,
+                account_id,
+                folder,
+            );
             let _ = std::fs::remove_file(file_path);
             return;
         }
@@ -779,7 +852,14 @@ fn process_pst_upload(
     let ipm_subtree_folder = match pst_store.open_folder(&ipm_sub_tree) {
         Ok(f) => f,
         Err(e) => {
-            fail_progress(import_id, "pst", &format!("{:?}", e), user_id, account_id, folder);
+            fail_progress(
+                import_id,
+                "pst",
+                &format!("{:?}", e),
+                user_id,
+                account_id,
+                folder,
+            );
             let _ = std::fs::remove_file(file_path);
             return;
         }
@@ -790,24 +870,27 @@ fn process_pst_upload(
     let format_str = "pst".to_string();
     pst::process_folder_with_progress(
         &ipm_subtree_folder,
-        "",  // parent_path starts empty
+        "", // parent_path starts empty
         account_id,
-        total,  // pass pre-counted total for accurate progress
+        total, // pass pre-counted total for accurate progress
         &mut success_count,
         &mut duplicate_count,
         &mut failed_details,
         &mut index,
         &|success, duplicates, actual_failed| {
-            update_progress(&import_id, ImportProgress {
-                import_id: import_id.clone(),
-                status: ImportStatus::Processing,
-                format: format_str.clone(),
-                total,
-                success,
-                duplicates,
-                failed: actual_failed,
-                failed_details: vec![],
-            });
+            update_progress(
+                &import_id,
+                ImportProgress {
+                    import_id: import_id.clone(),
+                    status: ImportStatus::Processing,
+                    format: format_str.clone(),
+                    total,
+                    success,
+                    duplicates,
+                    failed: actual_failed,
+                    failed_details: vec![],
+                },
+            );
         },
     );
 

--- a/crates/core/src/import/mod.rs
+++ b/crates/core/src/import/mod.rs
@@ -34,7 +34,7 @@ use crate::{
     {
         account::migration::{AccountModel, AccountType},
         cache::imap::mailbox::{Attribute, AttributeEnum, MailBox},
-        envelope::extractor::extract_envelope_from_eml,
+        envelope::extractor::{extract_envelope_from_eml, ExtractOutcome},
         error::{BichonResult, code::ErrorCode},
         settings::dir::DATA_DIR_MANAGER,
         utils::create_hash,
@@ -132,6 +132,7 @@ impl ImportEmls {
 
         let account_id = account.id;
         let mut success_count = 0;
+        let mut duplicate_count = 0;
         let mut failed_details: Vec<FailedItemDetail> = Vec::new(); // Store failure details
 
         let total = request.emls.len();
@@ -169,8 +170,11 @@ impl ImportEmls {
             }
 
             match extract_envelope_from_eml(&decoded, account_id, mailbox_id).await {
-                Ok(_) => {
+                Ok(ExtractOutcome::Imported) => {
                     success_count += 1;
+                },
+                Ok(ExtractOutcome::Duplicate) => {
+                    duplicate_count += 1;
                 },
                 Err(e) => {
                     let error_msg = format!(
@@ -194,7 +198,7 @@ impl ImportEmls {
         Ok(BatchEmlResult {
             total,
             success: success_count,
-            duplicates: 0,
+            duplicates: duplicate_count,
             failed: failed_count,
             failed_details, // Return the list of failure details
         })
@@ -566,7 +570,8 @@ fn process_eml_file(
         failed_details: vec![],
     });
 
-    let (success_count, failed_details) = process_single_eml(&file_bytes, 0, account_id, mailbox_id);
+    let (success_count, duplicate_count, failed_details) =
+        process_single_eml(&file_bytes, 0, account_id, mailbox_id);
 
     // Clean up
     let _ = std::fs::remove_file(file_path);
@@ -577,7 +582,7 @@ fn process_eml_file(
         format: "eml".to_string(),
         total,
         success: success_count,
-        duplicates: 0,
+        duplicates: duplicate_count,
         failed: failed_details.len(),
         failed_details,
     };
@@ -619,6 +624,7 @@ fn process_mbox_file(
     });
 
     let mut success_count = 0usize;
+    let mut duplicate_count = 0usize;
     let mut failed_details: Vec<FailedItemDetail> = Vec::new();
 
     for (index, entry) in mbox.iter().enumerate() {
@@ -639,8 +645,11 @@ fn process_mbox_file(
         }
 
         match futures::executor::block_on(extract_envelope_from_eml(eml_bytes, account_id, mailbox_id)) {
-            Ok(_) => {
+            Ok(ExtractOutcome::Imported) => {
                 success_count += 1;
+            }
+            Ok(ExtractOutcome::Duplicate) => {
+                duplicate_count += 1;
             }
             Err(e) => {
                 failed_details.push(FailedItemDetail {
@@ -658,7 +667,7 @@ fn process_mbox_file(
                 format: "mbox".to_string(),
                 total,
                 success: success_count,
-                duplicates: 0,
+                duplicates: duplicate_count,
                 failed: failed_details.len(),
                 failed_details: failed_details.clone(),
             });
@@ -675,7 +684,7 @@ fn process_mbox_file(
         format: "mbox".to_string(),
         total,
         success: success_count,
-        duplicates: 0,
+        duplicates: duplicate_count,
         failed: failed_details.len(),
         failed_details,
     };
@@ -683,16 +692,16 @@ fn process_mbox_file(
     update_progress(import_id, final_progress);
 }
 
-/// Process a single EML byte slice and return (success_count, failed_details).
+/// Process a single EML byte slice and return (success_count, duplicate_count, failed_details).
 fn process_single_eml(
     eml_bytes: &[u8],
     index: usize,
     account_id: u64,
     mailbox_id: u64,
-) -> (usize, Vec<FailedItemDetail>) {
+) -> (usize, usize, Vec<FailedItemDetail>) {
     if eml_bytes.len() > MAX_SINGLE_EML_BYTES {
         let size_mb = eml_bytes.len() as f64 / 1024.0 / 1024.0;
-        return (0, vec![FailedItemDetail {
+        return (0, 0, vec![FailedItemDetail {
             index,
             error_message: format!(
                 "Email is {:.1} MB (limit {} MB). Skipping.",
@@ -703,8 +712,9 @@ fn process_single_eml(
     }
 
     match futures::executor::block_on(extract_envelope_from_eml(eml_bytes, account_id, mailbox_id)) {
-        Ok(_) => (1, vec![]),
-        Err(e) => (0, vec![FailedItemDetail {
+        Ok(ExtractOutcome::Imported) => (1, 0, vec![]),
+        Ok(ExtractOutcome::Duplicate) => (0, 1, vec![]),
+        Err(e) => (0, 0, vec![FailedItemDetail {
             index,
             error_message: format!("{:?}", e),
         }]),
@@ -744,6 +754,7 @@ fn process_pst_upload(
 
     // Pass 2: process messages with progress updates
     let mut success_count: usize = 0;
+    let mut duplicate_count: usize = 0;
     let mut failed_details: Vec<FailedItemDetail> = Vec::new();
     let mut index: usize = 0;
 
@@ -783,16 +794,17 @@ fn process_pst_upload(
         account_id,
         total,  // pass pre-counted total for accurate progress
         &mut success_count,
+        &mut duplicate_count,
         &mut failed_details,
         &mut index,
-        &|processed, actual_failed| {
+        &|success, duplicates, actual_failed| {
             update_progress(&import_id, ImportProgress {
                 import_id: import_id.clone(),
                 status: ImportStatus::Processing,
                 format: format_str.clone(),
                 total,
-                success: processed - actual_failed,
-                duplicates: 0,
+                success,
+                duplicates,
                 failed: actual_failed,
                 failed_details: vec![],
             });
@@ -808,7 +820,7 @@ fn process_pst_upload(
         format: "pst".to_string(),
         total,
         success: success_count,
-        duplicates: 0,
+        duplicates: duplicate_count,
         failed: failed_details.len(),
         failed_details,
     };

--- a/crates/core/src/import/pst/mod.rs
+++ b/crates/core/src/import/pst/mod.rs
@@ -17,7 +17,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::base64_encode_url_safe;
-use crate::envelope::extractor::extract_envelope_from_eml;
+use crate::envelope::extractor::{extract_envelope_from_eml, ExtractOutcome};
 use chrono::{DateTime, TimeZone, Utc};
 use mail_send::mail_builder::headers::text::Text;
 use mail_send::mail_builder::MessageBuilder;
@@ -327,11 +327,12 @@ pub fn process_folder_with_progress<F>(
     account_id: u64,
     total: usize,
     success_count: &mut usize,
+    duplicate_count: &mut usize,
     failed_details: &mut Vec<super::FailedItemDetail>,
     index: &mut usize,
     progress_cb: &F,
 ) where
-    F: Fn(usize, usize), // (processed, failed)
+    F: Fn(usize, usize, usize), // (success, duplicates, failed)
 {
     process_folder_with_progress_inner(
         folder,
@@ -339,6 +340,7 @@ pub fn process_folder_with_progress<F>(
         account_id,
         total,
         success_count,
+        duplicate_count,
         failed_details,
         index,
         progress_cb,
@@ -351,11 +353,12 @@ fn process_folder_with_progress_inner<F>(
     account_id: u64,
     total: usize,
     success_count: &mut usize,
+    duplicate_count: &mut usize,
     failed_details: &mut Vec<super::FailedItemDetail>,
     index: &mut usize,
     progress_cb: &F,
 ) where
-    F: Fn(usize, usize),
+    F: Fn(usize, usize, usize),
 {
     let folder_name = folder
         .properties()
@@ -386,6 +389,7 @@ fn process_folder_with_progress_inner<F>(
                                 account_id,
                                 total,
                                 success_count,
+                                duplicate_count,
                                 failed_details,
                                 index,
                                 progress_cb,
@@ -437,8 +441,11 @@ fn process_folder_with_progress_inner<F>(
                         match futures::executor::block_on(
                             extract_envelope_from_eml(&decoded, account_id, mailbox_id)
                         ) {
-                            Ok(_) => {
+                            Ok(ExtractOutcome::Imported) => {
                                 *success_count += 1;
+                            }
+                            Ok(ExtractOutcome::Duplicate) => {
+                                *duplicate_count += 1;
                             }
                             Err(e) => {
                                 failed_details.push(super::FailedItemDetail {
@@ -459,7 +466,7 @@ fn process_folder_with_progress_inner<F>(
 
             // Report progress every 50 messages
             if batch_size % 50 == 0 {
-                progress_cb(*success_count + failed_details.len(), failed_details.len());
+                progress_cb(*success_count, *duplicate_count, failed_details.len());
             }
         }
     }
@@ -475,6 +482,7 @@ fn process_folder_with_progress_inner<F>(
                         account_id,
                         total,
                         success_count,
+                        duplicate_count,
                         failed_details,
                         index,
                         progress_cb,

--- a/crates/core/src/import/pst/mod.rs
+++ b/crates/core/src/import/pst/mod.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2025-2026 rustmailer.com (https://rustmailer.com)
 //
 // This file is part of the Bichon Email Archiving Project
@@ -16,17 +15,24 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::base64_encode_url_safe;
-use crate::envelope::extractor::{extract_envelope_from_eml, ExtractOutcome};
-use chrono::{DateTime, TimeZone, Utc};
-use mail_send::mail_builder::headers::text::Text;
-use mail_send::mail_builder::MessageBuilder;
-use outlook_pst::ltp::prop_context::PropertyValue;
-use outlook_pst::messaging::attachment::AttachmentProperties;
-use outlook_pst::messaging::folder::Folder;
-use outlook_pst::messaging::message::{Message, MessageProperties};
-use outlook_pst::ndb::node_id::NodeId;
 use std::rc::Rc;
+
+use chrono::{DateTime, TimeZone, Utc};
+use mail_send::mail_builder::{headers::text::Text, MessageBuilder};
+use outlook_pst::{
+    ltp::prop_context::PropertyValue,
+    messaging::{
+        attachment::AttachmentProperties,
+        folder::Folder,
+        message::{Message, MessageProperties},
+    },
+    ndb::node_id::NodeId,
+};
+
+use crate::{
+    base64_encode_url_safe,
+    envelope::extractor::{extract_envelope_from_eml, ExtractOutcome},
+};
 
 mod encoding;
 
@@ -193,7 +199,9 @@ fn extract_recipients_list(message: &Rc<dyn Message>) -> (Vec<String>, Vec<Strin
 }
 
 fn extract_subject(props: &MessageProperties) -> Option<String> {
-    props.get(0x0037).and_then(|val| encoding::decode_subject(val))
+    props
+        .get(0x0037)
+        .and_then(|val| encoding::decode_subject(val))
 }
 
 fn extract_string_property(properties: &MessageProperties, prop_id: u16) -> Option<String> {
@@ -268,12 +276,15 @@ pub fn count_pst_messages(pst_path: &std::path::Path) -> crate::error::BichonRes
         )
     })?;
 
-    let ipm_sub_tree = pst_store.properties().ipm_sub_tree_entry_id().map_err(|e| {
-        crate::raise_error!(
-            format!("Could not find IPM_SUBTREE in PST: {:?}", e),
-            crate::error::code::ErrorCode::InvalidParameter
-        )
-    })?;
+    let ipm_sub_tree = pst_store
+        .properties()
+        .ipm_sub_tree_entry_id()
+        .map_err(|e| {
+            crate::raise_error!(
+                format!("Could not find IPM_SUBTREE in PST: {:?}", e),
+                crate::error::code::ErrorCode::InvalidParameter
+            )
+        })?;
 
     let ipm_subtree_folder = pst_store.open_folder(&ipm_sub_tree).map_err(|e| {
         crate::raise_error!(
@@ -438,9 +449,9 @@ fn process_folder_with_progress_inner<F>(
                             }
                         };
 
-                        match futures::executor::block_on(
-                            extract_envelope_from_eml(&decoded, account_id, mailbox_id)
-                        ) {
+                        match futures::executor::block_on(extract_envelope_from_eml(
+                            &decoded, account_id, mailbox_id,
+                        )) {
                             Ok(ExtractOutcome::Imported) => {
                                 *success_count += 1;
                             }

--- a/crates/server/src/rest/api/import.rs
+++ b/crates/server/src/rest/api/import.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2025-2026 rustmailer.com (https://rustmailer.com)
 //
 // This file is part of the Bichon Email Archiving Project
@@ -18,45 +17,49 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::common::auth::WrappedContext;
-use crate::rest::api::ApiTags;
-use crate::rest::ApiResult;
-use bichon_core::account::migration::AccountModel;
-use bichon_core::database::manager::DB_MANAGER;
-use bichon_core::database::MemDbModel;
-use bichon_core::ext::event_bus::{emit, Event};
-use bichon_core::import::{
-    check_temp_disk_space, get_import_progress, process_uploaded_file, update_progress,
-    BatchEmlRequest, BatchEmlResult, ImportEmls, ImportHistory, ImportProgress, ImportStatus,
-    MAX_WEB_EML_BYTES,
+use bichon_core::{
+    account::migration::AccountModel,
+    database::{manager::DB_MANAGER, MemDbModel},
+    error::code::ErrorCode,
+    ext::event_bus::{emit, Event},
+    import::{
+        check_temp_disk_space, detect_text_file, get_import_progress,
+        history::{save_import_history, MAX_HISTORY_PER_USER},
+        process_uploaded_file, update_progress, BatchEmlRequest, BatchEmlResult, FileFormat,
+        ImportEmls, ImportHistory, ImportProgress, ImportStatus, MAX_WEB_EML_BYTES,
+    },
+    raise_error,
+    settings::{cli::SETTINGS, dir::DATA_DIR_MANAGER},
+    users::permissions::Permission,
 };
-use bichon_core::import::history::{save_import_history, MAX_HISTORY_PER_USER};
-use bichon_core::raise_error;
-use bichon_core::error::code::ErrorCode;
-use bichon_core::settings::cli::SETTINGS;
-use bichon_core::settings::dir::DATA_DIR_MANAGER;
-use bichon_core::users::permissions::Permission;
-use bichon_core::import::detect_text_file;
-use bichon_core::import::FileFormat;
 use futures::StreamExt;
 use poem::Body;
-use poem_openapi::param::{Path, Query};
-use poem_openapi::payload::{Json, Binary};
-use poem_openapi::OpenApi;
+use poem_openapi::{
+    param::{Path, Query},
+    payload::{Binary, Json},
+    OpenApi,
+};
 use tokio::io::AsyncWriteExt;
+
+use crate::{
+    common::auth::WrappedContext,
+    rest::{api::ApiTags, ApiResult},
+};
 
 pub struct ImportApi;
 
 #[OpenApi(prefix_path = "/api/v1", tag = "ApiTags::Import")]
 impl ImportApi {
-    /// Batch import one or more EML files into a specified account and mail folder.
+    /// Batch import one or more EML files into a specified account and mail
+    /// folder.
     ///
     /// This endpoint accepts a JSON payload containing:
     /// - `account_id`: the target account to import emails into
     /// - `mail_folder`: the mailbox/folder name
     /// - `emls`: a list of base64-encoded .eml files
     ///
-    /// Returns a summary of the import result, including total processed, successful, and failed emails.
+    /// Returns a summary of the import result, including total processed,
+    /// successful, and failed emails.
     #[oai(path = "/import", method = "post", operation_id = "do_batch_import")]
     async fn do_batch_import(
         &self,
@@ -107,19 +110,25 @@ impl ImportApi {
 
     /// Upload an EML or MBOX file for import into a NoSync account.
     ///
-    /// The file is sent as the raw request body. Both `account_id` and `mail_folder`
-    /// must be provided as query parameters, along with the original `file_name` for
-    /// extension validation.
+    /// The file is sent as the raw request body. Both `account_id` and
+    /// `mail_folder` must be provided as query parameters, along with the
+    /// original `file_name` for extension validation.
     ///
-    /// Returns an `import_id` to poll for progress via `/import-progress/:import_id`.
-    #[oai(path = "/upload-import", method = "post", operation_id = "upload_import")]
+    /// Returns an `import_id` to poll for progress via
+    /// `/import-progress/:import_id`.
+    #[oai(
+        path = "/upload-import",
+        method = "post",
+        operation_id = "upload_import"
+    )]
     async fn upload_import(
         &self,
         /// Target account ID (must be NoSync type).
         account_id: Query<u64>,
         /// Target mail folder name.
         mail_folder: Query<String>,
-        /// Original file name, used for extension validation (e.g. "export.eml").
+        /// Original file name, used for extension validation (e.g.
+        /// "export.eml").
         file_name: Query<String>,
         /// The raw file bytes (.eml or .mbox).
         data: Binary<Body>,
@@ -197,14 +206,12 @@ impl ImportApi {
                 .unwrap_or_default()
                 .as_nanos()
         );
-        let temp_path = DATA_DIR_MANAGER.temp_dir.join(format!("import_{}.tmp", import_id));
+        let temp_path = DATA_DIR_MANAGER
+            .temp_dir
+            .join(format!("import_{}.tmp", import_id));
 
-        let (format_detected, file_len) = stream_body_to_temp(
-            data.0,
-            &temp_path,
-            is_mbox_ext,
-            is_pst_ext,
-        ).await?;
+        let (format_detected, file_len) =
+            stream_body_to_temp(data.0, &temp_path, is_mbox_ext, is_pst_ext).await?;
 
         let format = format_detected.unwrap_or_else(|| {
             if is_mbox_ext {
@@ -270,7 +277,14 @@ impl ImportApi {
             failed: 0,
         });
         tokio::task::spawn_blocking(move || {
-            process_uploaded_file(&id, &temp_path, &file_name, account_id, &folder_clone, user_id);
+            process_uploaded_file(
+                &id,
+                &temp_path,
+                &file_name,
+                account_id,
+                &folder_clone,
+                user_id,
+            );
         });
 
         Ok(Json(initial))
@@ -308,7 +322,8 @@ impl ImportApi {
         Ok(Json(free))
     }
 
-    /// List import history for the current user (latest first, up to 5 entries).
+    /// List import history for the current user (latest first, up to 5
+    /// entries).
     #[oai(
         path = "/import-history",
         method = "get",

--- a/crates/server/src/rest/api/import.rs
+++ b/crates/server/src/rest/api/import.rs
@@ -88,7 +88,7 @@ impl ImportApi {
             ),
             status: if result.failed == 0 {
                 ImportStatus::Completed
-            } else if result.success == 0 {
+            } else if result.success == 0 && result.duplicates == 0 {
                 ImportStatus::Failed
             } else {
                 ImportStatus::Completed

--- a/crates/server/src/rest/api/import.rs
+++ b/crates/server/src/rest/api/import.rs
@@ -77,6 +77,7 @@ impl ImportApi {
             format: "eml".to_string(),
             total: result.total as u64,
             success: result.success as u64,
+            duplicates: result.duplicates as u64,
             failed: result.failed as u64,
         });
 
@@ -274,6 +275,7 @@ impl ImportApi {
             format: format_str.clone(),
             total: 0,
             success: 0,
+            duplicates: 0,
             failed: 0,
         });
         tokio::task::spawn_blocking(move || {

--- a/crates/smtp/src/server.rs
+++ b/crates/smtp/src/server.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2025-2026 rustmailer.com (https://rustmailer.com)
 //
 // This file is part of the Bichon Email Archiving Project
@@ -16,37 +15,31 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::io;
-use std::net::SocketAddr;
-use std::time::Duration;
+use std::{io, net::SocketAddr, time::Duration};
 
 use base64::{prelude::BASE64_STANDARD, Engine as _};
-use bichon_core::account::migration::AccountType;
-use bichon_core::cache::imap::mailbox::{Attribute, AttributeEnum};
-use bichon_core::common::signal::SIGNAL_MANAGER;
-use bichon_core::envelope::extractor::extract_envelope_from_smtp;
-use bichon_core::error::BichonResult;
-use bichon_core::settings::cli::{EncryptionMode, SETTINGS};
-use bichon_core::utils::create_hash;
 use bichon_core::{
-    account::migration::AccountModel,
-    cache::imap::mailbox::MailBox,
-    common::auth::ClientContext,
+    account::migration::{AccountModel, AccountType},
+    cache::imap::mailbox::{Attribute, AttributeEnum, MailBox},
+    common::{auth::ClientContext, signal::SIGNAL_MANAGER},
+    envelope::extractor::extract_envelope_from_smtp,
+    error::BichonResult,
+    settings::cli::{EncryptionMode, SETTINGS},
     token::AccessTokenModel,
     users::{permissions::Permission, UserModel},
+    utils::create_hash,
 };
-use tokio::time::timeout;
 use tokio::{
     io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt},
     net::{TcpListener, TcpStream},
     sync::broadcast,
+    time::timeout,
 };
 use tokio_rustls::TlsAcceptor;
 
-use crate::stream::BufStream;
-use crate::tls::create_acceptor;
+use crate::{stream::BufStream, tls::create_acceptor};
 
-const MAX_MAIL_SIZE: usize = 50 * 1024 * 1024; //50MB
+const MAX_MAIL_SIZE: usize = 50 * 1024 * 1024; // 50MB
 const SMTP_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 const GLOBAL_SESSION_TIMEOUT: Duration = Duration::from_secs(600);
 
@@ -394,7 +387,7 @@ where
                 .await?;
         } else {
             let addr = extract_address(&trimmed[8..]);
-            //println!("DEBUG: SMTP RCPT TO extracted address -> '{}'", addr);
+            // println!("DEBUG: SMTP RCPT TO extracted address -> '{}'", addr);
             let account_result = AccountModel::find_by_email(addr.as_str());
 
             match account_result {

--- a/crates/smtp/src/server.rs
+++ b/crates/smtp/src/server.rs
@@ -666,6 +666,7 @@ async fn parse_email(data: &[u8], session: &Session) -> BichonResult<()> {
 
     extract_envelope_from_smtp(data, rcpt.id, mailbox_id)
         .await
+        .map(|_| ())
         .map_err(|e| {
             tracing::error!(
                 "SMTP: Envelope extraction failed for {}: {:?}",

--- a/web/src/features/import/index.tsx
+++ b/web/src/features/import/index.tsx
@@ -681,7 +681,7 @@ export default function ImportPage() {
                       {t('import.failedCount', { count: progress.failed })}
                     </span>
                     {progress.duplicates > 0 && (
-                      <span className="flex items-center gap-1">
+                      <span className="flex items-center gap-1" title={t('import.duplicateCountHint')}>
                         <Copy className="h-3.5 w-3.5 text-muted-foreground" />
                         {t('import.duplicateCount', { count: progress.duplicates })}
                       </span>

--- a/web/src/features/import/index.tsx
+++ b/web/src/features/import/index.tsx
@@ -119,6 +119,9 @@ export default function ImportPage() {
 
   const abortRef = useRef<AbortController | null>(null);
 
+  const processedCount = progress ? progress.success + progress.failed + progress.duplicates : 0;
+  const processedPct = progress && progress.total > 0 ? (processedCount / progress.total) * 100 : 0;
+
   useEffect(() => {
     return () => { abortRef.current?.abort(); };
   }, []);
@@ -659,18 +662,11 @@ export default function ImportPage() {
                   <div className="space-y-1.5">
                     <div className="flex justify-between text-xs text-muted-foreground">
                       <span>
-                        {t('import.processed', { current: progress.success + progress.failed + progress.duplicates, total: progress.total })}
+                        {t('import.processed', { current: processedCount, total: progress.total })}
                       </span>
-                      <span>
-                        {progress.total > 0
-                          ? Math.round(((progress.success + progress.failed + progress.duplicates) / progress.total) * 100)
-                          : 0}%
-                      </span>
+                      <span>{Math.round(processedPct)}%</span>
                     </div>
-                    <Progress
-                      value={progress.total > 0 ? ((progress.success + progress.failed + progress.duplicates) / progress.total) * 100 : 0}
-                      className="h-2"
-                    />
+                    <Progress value={processedPct} className="h-2" />
                   </div>
                 )}
 

--- a/web/src/features/import/index.tsx
+++ b/web/src/features/import/index.tsx
@@ -9,7 +9,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import {
   Upload, FileText, X, CheckCircle2, AlertTriangle,
   Sparkles, PenLine, ListTree, ChevronsUpDown, Check,
-  Clock, ChevronRight,
+  Clock, ChevronRight, Copy,
 } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -659,16 +659,16 @@ export default function ImportPage() {
                   <div className="space-y-1.5">
                     <div className="flex justify-between text-xs text-muted-foreground">
                       <span>
-                        {t('import.processed', { current: progress.success + progress.failed, total: progress.total })}
+                        {t('import.processed', { current: progress.success + progress.failed + progress.duplicates, total: progress.total })}
                       </span>
                       <span>
                         {progress.total > 0
-                          ? Math.round(((progress.success + progress.failed) / progress.total) * 100)
+                          ? Math.round(((progress.success + progress.failed + progress.duplicates) / progress.total) * 100)
                           : 0}%
                       </span>
                     </div>
                     <Progress
-                      value={progress.total > 0 ? ((progress.success + progress.failed) / progress.total) * 100 : 0}
+                      value={progress.total > 0 ? ((progress.success + progress.failed + progress.duplicates) / progress.total) * 100 : 0}
                       className="h-2"
                     />
                   </div>
@@ -684,6 +684,12 @@ export default function ImportPage() {
                       <AlertTriangle className="h-3.5 w-3.5 text-amber-600" />
                       {t('import.failedCount', { count: progress.failed })}
                     </span>
+                    {progress.duplicates > 0 && (
+                      <span className="flex items-center gap-1">
+                        <Copy className="h-3.5 w-3.5 text-muted-foreground" />
+                        {t('import.duplicateCount', { count: progress.duplicates })}
+                      </span>
+                    )}
                   </div>
                 )}
 

--- a/web/src/locales/ar.json
+++ b/web/src/locales/ar.json
@@ -727,6 +727,7 @@
     "detectedFolder": "مكتشف",
     "detectedFrom": "مكتشف من",
     "dropHere": "أفلت ملفات .eml / .mbox / .pst هنا",
+    "duplicateCount": "تم تخطي {{count}} من التكرارات",
     "failed": "فشل الاستيراد",
     "failedCount": "{{count}} فشل",
     "failedDetails": "العناصر الفاشلة",

--- a/web/src/locales/ar.json
+++ b/web/src/locales/ar.json
@@ -728,6 +728,7 @@
     "detectedFrom": "مكتشف من",
     "dropHere": "أفلت ملفات .eml / .mbox / .pst هنا",
     "duplicateCount": "تم تخطي {{count}} من التكرارات",
+    "duplicateCountHint": "هذه الرسائل مؤرشفة بالفعل",
     "failed": "فشل الاستيراد",
     "failedCount": "{{count}} فشل",
     "failedDetails": "العناصر الفاشلة",

--- a/web/src/locales/da.json
+++ b/web/src/locales/da.json
@@ -727,6 +727,7 @@
     "detectedFolder": "Registreret",
     "detectedFrom": "Registreret fra",
     "dropHere": "Slip .eml / .mbox / .pst-filer her",
+    "duplicateCount": "{{count}} dubletter sprunget over",
     "failed": "Import mislykkedes",
     "failedCount": "{{count}} fejlet",
     "failedDetails": "Fejlede elementer",

--- a/web/src/locales/da.json
+++ b/web/src/locales/da.json
@@ -728,6 +728,7 @@
     "detectedFrom": "Registreret fra",
     "dropHere": "Slip .eml / .mbox / .pst-filer her",
     "duplicateCount": "{{count}} dubletter sprunget over",
+    "duplicateCountHint": "Disse beskeder er allerede arkiveret",
     "failed": "Import mislykkedes",
     "failedCount": "{{count}} fejlet",
     "failedDetails": "Fejlede elementer",

--- a/web/src/locales/de.json
+++ b/web/src/locales/de.json
@@ -728,6 +728,7 @@
     "detectedFrom": "Erkannt aus",
     "dropHere": ".eml / .mbox / .pst-Dateien hierher ziehen",
     "duplicateCount": "{{count}} Duplikate übersprungen",
+    "duplicateCountHint": "Diese Nachrichten sind bereits archiviert",
     "failed": "Import fehlgeschlagen",
     "failedCount": "{{count}} fehlgeschlagen",
     "failedDetails": "Fehlgeschlagene Elemente",

--- a/web/src/locales/de.json
+++ b/web/src/locales/de.json
@@ -727,6 +727,7 @@
     "detectedFolder": "Erkannt",
     "detectedFrom": "Erkannt aus",
     "dropHere": ".eml / .mbox / .pst-Dateien hierher ziehen",
+    "duplicateCount": "{{count}} Duplikate übersprungen",
     "failed": "Import fehlgeschlagen",
     "failedCount": "{{count}} fehlgeschlagen",
     "failedDetails": "Fehlgeschlagene Elemente",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -739,6 +739,7 @@
     "detectedFolder": "Detected",
     "detectedFrom": "Detected from",
     "dropHere": "Drop .eml / .mbox / .pst files here",
+    "duplicateCount": "{{count}} duplicates skipped",
     "failed": "Import failed",
     "failedCount": "{{count}} failed",
     "failedDetails": "Failed items",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -740,6 +740,7 @@
     "detectedFrom": "Detected from",
     "dropHere": "Drop .eml / .mbox / .pst files here",
     "duplicateCount": "{{count}} duplicates skipped",
+    "duplicateCountHint": "These messages are already in the archive",
     "failed": "Import failed",
     "failedCount": "{{count}} failed",
     "failedDetails": "Failed items",

--- a/web/src/locales/es.json
+++ b/web/src/locales/es.json
@@ -727,6 +727,7 @@
     "detectedFolder": "Detectado",
     "detectedFrom": "Detectado de",
     "dropHere": "Arrastre archivos .eml / .mbox / .pst aquí",
+    "duplicateCount": "{{count}} duplicados omitidos",
     "failed": "Error al importar",
     "failedCount": "{{count}} fallidos",
     "failedDetails": "Elementos fallidos",

--- a/web/src/locales/es.json
+++ b/web/src/locales/es.json
@@ -728,6 +728,7 @@
     "detectedFrom": "Detectado de",
     "dropHere": "Arrastre archivos .eml / .mbox / .pst aquí",
     "duplicateCount": "{{count}} duplicados omitidos",
+    "duplicateCountHint": "Estos mensajes ya están archivados",
     "failed": "Error al importar",
     "failedCount": "{{count}} fallidos",
     "failedDetails": "Elementos fallidos",

--- a/web/src/locales/fi.json
+++ b/web/src/locales/fi.json
@@ -728,6 +728,7 @@
     "detectedFrom": "Tunnistettu lähteestä",
     "dropHere": "Pudota .eml / .mbox / .pst -tiedostot tähän",
     "duplicateCount": "{{count}} kaksoiskappaletta ohitettu",
+    "duplicateCountHint": "Nämä viestit on jo arkistoitu",
     "failed": "Tuonti epäonnistui",
     "failedCount": "{{count}} epäonnistui",
     "failedDetails": "Epäonnistuneet kohteet",

--- a/web/src/locales/fi.json
+++ b/web/src/locales/fi.json
@@ -727,6 +727,7 @@
     "detectedFolder": "Tunnistettu",
     "detectedFrom": "Tunnistettu lähteestä",
     "dropHere": "Pudota .eml / .mbox / .pst -tiedostot tähän",
+    "duplicateCount": "{{count}} kaksoiskappaletta ohitettu",
     "failed": "Tuonti epäonnistui",
     "failedCount": "{{count}} epäonnistui",
     "failedDetails": "Epäonnistuneet kohteet",

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -727,6 +727,7 @@
     "detectedFolder": "Détecté",
     "detectedFrom": "Détecté depuis",
     "dropHere": "Déposez les fichiers .eml / .mbox / .pst ici",
+    "duplicateCount": "{{count}} doublon(s) ignoré(s)",
     "failed": "Échec de l'importation",
     "failedCount": "{{count}} échoué(s)",
     "failedDetails": "Éléments en échec",

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -728,6 +728,7 @@
     "detectedFrom": "Détecté depuis",
     "dropHere": "Déposez les fichiers .eml / .mbox / .pst ici",
     "duplicateCount": "{{count}} doublon(s) ignoré(s)",
+    "duplicateCountHint": "Ces messages sont déjà archivés",
     "failed": "Échec de l'importation",
     "failedCount": "{{count}} échoué(s)",
     "failedDetails": "Éléments en échec",

--- a/web/src/locales/it.json
+++ b/web/src/locales/it.json
@@ -727,6 +727,7 @@
     "detectedFolder": "Rilevato",
     "detectedFrom": "Rilevato da",
     "dropHere": "Trascina i file .eml / .mbox / .pst qui",
+    "duplicateCount": "{{count}} duplicati saltati",
     "failed": "Importazione fallita",
     "failedCount": "{{count}} falliti",
     "failedDetails": "Elementi falliti",

--- a/web/src/locales/it.json
+++ b/web/src/locales/it.json
@@ -728,6 +728,7 @@
     "detectedFrom": "Rilevato da",
     "dropHere": "Trascina i file .eml / .mbox / .pst qui",
     "duplicateCount": "{{count}} duplicati saltati",
+    "duplicateCountHint": "Questi messaggi sono già archiviati",
     "failed": "Importazione fallita",
     "failedCount": "{{count}} falliti",
     "failedDetails": "Elementi falliti",

--- a/web/src/locales/jp.json
+++ b/web/src/locales/jp.json
@@ -727,6 +727,7 @@
     "detectedFolder": "放出演出",
     "detectedFrom": "検出元:",
     "dropHere": "ここに .eml / .mbox / .pst 文件をドロップ",
+    "duplicateCount": "{{count}} 件の重複をスキップ",
     "failed": "インポート失敗",
     "failedCount": "{{count}} 件の失敗",
     "failedDetails": "失敗したアイテム",

--- a/web/src/locales/jp.json
+++ b/web/src/locales/jp.json
@@ -728,6 +728,7 @@
     "detectedFrom": "検出元:",
     "dropHere": "ここに .eml / .mbox / .pst 文件をドロップ",
     "duplicateCount": "{{count}} 件の重複をスキップ",
+    "duplicateCountHint": "これらのメッセージは既にアーカイブ済みです",
     "failed": "インポート失敗",
     "failedCount": "{{count}} 件の失敗",
     "failedDetails": "失敗したアイテム",

--- a/web/src/locales/ko.json
+++ b/web/src/locales/ko.json
@@ -728,6 +728,7 @@
     "detectedFrom": "감지 대상:",
     "dropHere": "여기에 .eml / .mbox / .pst 파일 끌어놓기",
     "duplicateCount": "{{count}}개 중복 건너뜀",
+    "duplicateCountHint": "이미 아카이브된 메시지입니다",
     "failed": "가져오기 실패",
     "failedCount": "{{count}}개 실패",
     "failedDetails": "실패한 항목",

--- a/web/src/locales/ko.json
+++ b/web/src/locales/ko.json
@@ -727,6 +727,7 @@
     "detectedFolder": "감지됨",
     "detectedFrom": "감지 대상:",
     "dropHere": "여기에 .eml / .mbox / .pst 파일 끌어놓기",
+    "duplicateCount": "{{count}}개 중복 건너뜀",
     "failed": "가져오기 실패",
     "failedCount": "{{count}}개 실패",
     "failedDetails": "실패한 항목",

--- a/web/src/locales/nl.json
+++ b/web/src/locales/nl.json
@@ -728,6 +728,7 @@
     "detectedFrom": "Gedetecteerd uit",
     "dropHere": "Sleep .eml / .mbox / .pst bestanden hierheen",
     "duplicateCount": "{{count}} duplicaten overgeslagen",
+    "duplicateCountHint": "Deze berichten zijn al gearchiveerd",
     "failed": "Import mislukt",
     "failedCount": "{{count}} mislukt",
     "failedDetails": "Mislukte items",

--- a/web/src/locales/nl.json
+++ b/web/src/locales/nl.json
@@ -727,6 +727,7 @@
     "detectedFolder": "Gedetecteerd",
     "detectedFrom": "Gedetecteerd uit",
     "dropHere": "Sleep .eml / .mbox / .pst bestanden hierheen",
+    "duplicateCount": "{{count}} duplicaten overgeslagen",
     "failed": "Import mislukt",
     "failedCount": "{{count}} mislukt",
     "failedDetails": "Mislukte items",

--- a/web/src/locales/no.json
+++ b/web/src/locales/no.json
@@ -728,6 +728,7 @@
     "detectedFrom": "Registrert fra",
     "dropHere": "Slipp .eml / .mbox / .pst-filer her",
     "duplicateCount": "{{count}} duplikater hoppet over",
+    "duplicateCountHint": "Disse meldingene er allerede arkivert",
     "failed": "Import mislyktes",
     "failedCount": "{{count}} feilet",
     "failedDetails": "Feilede elementer",

--- a/web/src/locales/no.json
+++ b/web/src/locales/no.json
@@ -727,6 +727,7 @@
     "detectedFolder": "Registrert",
     "detectedFrom": "Registrert fra",
     "dropHere": "Slipp .eml / .mbox / .pst-filer her",
+    "duplicateCount": "{{count}} duplikater hoppet over",
     "failed": "Import mislyktes",
     "failedCount": "{{count}} feilet",
     "failedDetails": "Feilede elementer",

--- a/web/src/locales/pl.json
+++ b/web/src/locales/pl.json
@@ -727,6 +727,7 @@
     "detectedFolder": "Wykryto",
     "detectedFrom": "Wykryto z",
     "dropHere": "Upuść pliki .eml / .mbox / .pst tutaj",
+    "duplicateCount": "Pominięto duplikatów: {{count}}",
     "failed": "Import nie powiódł się",
     "failedCount": "Niepowodzenie: {{count}}",
     "failedDetails": "Nieudane elementy",

--- a/web/src/locales/pl.json
+++ b/web/src/locales/pl.json
@@ -728,6 +728,7 @@
     "detectedFrom": "Wykryto z",
     "dropHere": "Upuść pliki .eml / .mbox / .pst tutaj",
     "duplicateCount": "Pominięto duplikatów: {{count}}",
+    "duplicateCountHint": "Te wiadomości są już zarchiwizowane",
     "failed": "Import nie powiódł się",
     "failedCount": "Niepowodzenie: {{count}}",
     "failedDetails": "Nieudane elementy",

--- a/web/src/locales/pt.json
+++ b/web/src/locales/pt.json
@@ -727,6 +727,7 @@
     "detectedFolder": "Detectado",
     "detectedFrom": "Detectado de",
     "dropHere": "Solte arquivos .eml / .mbox / .pst aqui",
+    "duplicateCount": "{{count}} duplicados ignorados",
     "failed": "Falha na importação",
     "failedCount": "{{count}} falharam",
     "failedDetails": "Itens com falha",

--- a/web/src/locales/pt.json
+++ b/web/src/locales/pt.json
@@ -728,6 +728,7 @@
     "detectedFrom": "Detectado de",
     "dropHere": "Solte arquivos .eml / .mbox / .pst aqui",
     "duplicateCount": "{{count}} duplicados ignorados",
+    "duplicateCountHint": "Estas mensagens já estão arquivadas",
     "failed": "Falha na importação",
     "failedCount": "{{count}} falharam",
     "failedDetails": "Itens com falha",

--- a/web/src/locales/ru.json
+++ b/web/src/locales/ru.json
@@ -727,6 +727,7 @@
     "detectedFolder": "Обнаружено",
     "detectedFrom": "Обнаружено из",
     "dropHere": "Перетащите файлы .eml / .mbox / .pst сюда",
+    "duplicateCount": "Пропущено дубликатов: {{count}}",
     "failed": "Ошибка импорта",
     "failedCount": "Ошибок: {{count}}",
     "failedDetails": "Неудачные элементы",

--- a/web/src/locales/ru.json
+++ b/web/src/locales/ru.json
@@ -728,6 +728,7 @@
     "detectedFrom": "Обнаружено из",
     "dropHere": "Перетащите файлы .eml / .mbox / .pst сюда",
     "duplicateCount": "Пропущено дубликатов: {{count}}",
+    "duplicateCountHint": "Эти сообщения уже в архиве",
     "failed": "Ошибка импорта",
     "failedCount": "Ошибок: {{count}}",
     "failedDetails": "Неудачные элементы",

--- a/web/src/locales/sv.json
+++ b/web/src/locales/sv.json
@@ -727,6 +727,7 @@
     "detectedFolder": "Identifierad",
     "detectedFrom": "Identifierad från",
     "dropHere": "Släpp .eml / .mbox / .pst-filer här",
+    "duplicateCount": "{{count}} dubbletter hoppades över",
     "failed": "Import misslyckades",
     "failedCount": "{{count}} misslyckades",
     "failedDetails": "Misslyckade objekt",

--- a/web/src/locales/sv.json
+++ b/web/src/locales/sv.json
@@ -728,6 +728,7 @@
     "detectedFrom": "Identifierad från",
     "dropHere": "Släpp .eml / .mbox / .pst-filer här",
     "duplicateCount": "{{count}} dubbletter hoppades över",
+    "duplicateCountHint": "Dessa meddelanden är redan arkiverade",
     "failed": "Import misslyckades",
     "failedCount": "{{count}} misslyckades",
     "failedDetails": "Misslyckade objekt",

--- a/web/src/locales/zh-tw.json
+++ b/web/src/locales/zh-tw.json
@@ -728,6 +728,7 @@
     "detectedFrom": "識別自",
     "dropHere": "將 .eml / .mbox / .pst 檔案拖曳到此處",
     "duplicateCount": "已略過 {{count}} 個重複項",
+    "duplicateCountHint": "這些郵件已封存",
     "failed": "匯入失敗",
     "failedCount": "{{count}} 個失敗",
     "failedDetails": "失敗詳情",

--- a/web/src/locales/zh-tw.json
+++ b/web/src/locales/zh-tw.json
@@ -727,6 +727,7 @@
     "detectedFolder": "已識別",
     "detectedFrom": "識別自",
     "dropHere": "將 .eml / .mbox / .pst 檔案拖曳到此處",
+    "duplicateCount": "已略過 {{count}} 個重複項",
     "failed": "匯入失敗",
     "failedCount": "{{count}} 個失敗",
     "failedDetails": "失敗詳情",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -737,6 +737,7 @@
     "detectedFolder": "已识别",
     "detectedFrom": "识别自",
     "dropHere": "将 .eml / .mbox / .pst 文件拖拽到此处",
+    "duplicateCount": "已跳过 {{count}} 个重复项",
     "failed": "导入失败",
     "failedCount": "{{count}} 个失败",
     "failedDetails": "失败详情",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -738,6 +738,7 @@
     "detectedFrom": "识别自",
     "dropHere": "将 .eml / .mbox / .pst 文件拖拽到此处",
     "duplicateCount": "已跳过 {{count}} 个重复项",
+    "duplicateCountHint": "这些邮件已归档",
     "failed": "导入失败",
     "failedCount": "{{count}} 个失败",
     "failedDetails": "失败详情",


### PR DESCRIPTION
Fixes #348

Re-importing already-archived messages reported them as imported: the BLAKE3 dedup hit in `extract_envelope_core` returned the same `Ok(())` as a real import, so every surface counted it as a success and every `duplicates` field stayed a hardcoded 0.

`extract_envelope_core` now returns an explicit `ExtractOutcome::{Imported, Duplicate}` and each import loop counts it:

| Surface | Change |
|---|---|
| batch `POST /api/v1/import` | `Duplicate` → `duplicates`, not `success` (`crates/core/src/import/mod.rs`) |
| upload EML / MBOX | same; per-file progress carries the count |
| upload PST | same (`crates/core/src/import/pst/mod.rs`) |
| CLI | inherits the fixed batch counts, no change needed |
| SMTP receive | outcome explicitly ignored (`crates/smtp/src/server.rs`) |

Semantics on every path: `total = success + duplicates + failed`; an all-duplicates run reports `completed`; duplicates produce no `failed_details` entries. The `ImportPerformed` audit event carries the count.

WebUI: shows the duplicates count in import progress, aggregated across multi-file selections, with a hover note that duplicates were already archived. Strings added to all 16 locales.

<img width="1582" height="1286" alt="screenshot-2026-08-18_22-45-00" src="https://github.com/user-attachments/assets/f2a08a59-f310-4ced-a447-a177be9198ac" />


## Test plan

- [x] live REST: import 2 EMLs → `success 2, duplicates 0`; re-import the same 2 → `success 0, duplicates 2, failed 0, total 2`, history status `completed`, no `failed_details`
- [x] WebUI: re-importing the same files shows the duplicates counter in import progress and counts duplicates toward the processed %
- [x] `cargo check --workspace` clean
- [x] import feature vitest: 16/16
